### PR TITLE
Adding mechanism to add new event handlers during runtime

### DIFF
--- a/bundles/org.palladiosimulator.analyzer.slingshot.core/src/org/palladiosimulator/analyzer/slingshot/core/api/BusBasedDriver.java
+++ b/bundles/org.palladiosimulator.analyzer.slingshot.core/src/org/palladiosimulator/analyzer/slingshot/core/api/BusBasedDriver.java
@@ -1,18 +1,59 @@
 package org.palladiosimulator.analyzer.slingshot.core.api;
 
+import java.util.function.Consumer;
 import java.util.function.Function;
 
 import org.palladiosimulator.analyzer.slingshot.core.extension.SimulationBehaviorExtension;
 import org.palladiosimulator.analyzer.slingshot.eventdriver.returntypes.Result;
 
+/**
+ * An interface that allows for adding handlers to a driver that uses
+ * event bus.
+ * 
+ * @author Julijan Katic
+ */
 public interface BusBasedDriver {
 
 
+	/**
+	 * Registers an entire object that contain event handlers.
+	 * 
+	 * @param handlers An object that contains event handlers.
+	 */
 	public void registerHandlers(final SimulationBehaviorExtension handlers);
 	
+	/**
+	 * Registers an event handler directly. The event handler can be a anonymous
+	 * lambda function. 
+	 * 
+	 * @param <T> The event type itself.
+	 * @param id An id that identifies this handler. This can be used to unregister again.
+	 * @param forEvent The event type.
+	 * @param handler The handler/subscriber.
+	 * @see {@link #registerHandler(String, Class, Consumer)}
+	 */
 	public <T> void registerHandler(
 			final String id,
 			final Class<T> forEvent, 
 			final Function<T, Result<?>> handler);
 	
+	/**
+	 * Registers an event handler without a {@link Result}. This is similar to {@link #registerHandler(String, Class, Function)}.
+	 * 
+	 * @param <T> The event type itself.
+	 * @param id An id that identifies this handler. This can be used to unregister again.
+	 * @param forEvent The event type.
+	 * @param handler The handler/subscriber.
+	 * @see {@link #registerHandler(String, Class, Function)}
+	 */
+	default public <T> void registerHandler(
+			final String id,
+			final Class<T> forEvent,
+			final Consumer<T> handler
+			) {
+		this.registerHandler(id, forEvent, event -> {
+			handler.accept(event);
+			return Result.empty();
+		});
+	}
 }

--- a/bundles/org.palladiosimulator.analyzer.slingshot.core/src/org/palladiosimulator/analyzer/slingshot/core/api/BusBasedDriver.java
+++ b/bundles/org.palladiosimulator.analyzer.slingshot.core/src/org/palladiosimulator/analyzer/slingshot/core/api/BusBasedDriver.java
@@ -1,0 +1,18 @@
+package org.palladiosimulator.analyzer.slingshot.core.api;
+
+import java.util.function.Function;
+
+import org.palladiosimulator.analyzer.slingshot.core.extension.SimulationBehaviorExtension;
+import org.palladiosimulator.analyzer.slingshot.eventdriver.returntypes.Result;
+
+public interface BusBasedDriver {
+
+
+	public void registerHandlers(final SimulationBehaviorExtension handlers);
+	
+	public <T> void registerHandler(
+			final String id,
+			final Class<T> forEvent, 
+			final Function<T, Result<?>> handler);
+	
+}

--- a/bundles/org.palladiosimulator.analyzer.slingshot.core/src/org/palladiosimulator/analyzer/slingshot/core/api/SimulationDriver.java
+++ b/bundles/org.palladiosimulator.analyzer.slingshot.core/src/org/palladiosimulator/analyzer/slingshot/core/api/SimulationDriver.java
@@ -1,22 +1,61 @@
 package org.palladiosimulator.analyzer.slingshot.core.api;
 
-import java.util.function.Function;
-
 import org.eclipse.core.runtime.IProgressMonitor;
-import org.palladiosimulator.analyzer.slingshot.core.extension.SimulationBehaviorExtension;
-import org.palladiosimulator.analyzer.slingshot.eventdriver.returntypes.Result;
-import org.palladiosimulator.analyzer.workflow.blackboard.PCMResourceSetPartition;
 
 import de.uka.ipd.sdq.simucomframework.SimuComConfig;
 
+/**
+ * An interface describing (event bus) driver for the simulation run.
+ * One is able to start and stop the simulation through this interface. However,
+ * before the simulation is started, one needs to first initialize it with
+ * {@link #init(SimuComConfig, IProgressMonitor)}
+ * 
+ * @author Julijan Katic
+ */
 public interface SimulationDriver extends SimulationScheduling, BusBasedDriver {
 	
+	/**
+	 * Initializes the driver using the {@code SimuComConfig} configuration and the
+	 * progress monitor. This can also be used to re-initialize the driver.
+	 * 
+	 * @param config The (launch) configuration for the simulation.
+	 * @param monitor The monitor to describe the overall progress of the simulation.
+	 */
 	public void init(final SimuComConfig config, final IProgressMonitor monitor);
 	
+	/**
+	 * Starts the simulation. Note that the driver must first be initialized.
+	 * 
+	 * @throws IllegalStateException if the driver wasn't initialized before.
+	 * @see #init(SimuComConfig, IProgressMonitor)
+	 * @see #isInitialized()
+	 */
 	public void start();
 	
+	/**
+	 * Stops the simulation. It won't do anything if the simulation is not
+	 * running.
+	 */
 	public void stop();
 	
+	/**
+	 * Returns whether the simulation is currently running and accepting events.
+	 * 
+	 * @return True if and only if the simulation is running.
+	 */
 	public boolean isRunning();
+	
+	/**
+	 * Shuts down the driver and de-initializes it. This means that all references
+	 * are destroyed, and {@link #isInitialized()} will return {@code false} again
+	 * from this point on. Thus, one needs to initialize the driver again to use it.
+	 */
+	public void shutdown();
+	
+	/**
+	 * Returns whether the driver is now correctly initialized.
+	 * @return
+	 */
+	public boolean isInitialized();
 	
 }

--- a/bundles/org.palladiosimulator.analyzer.slingshot.core/src/org/palladiosimulator/analyzer/slingshot/core/api/SimulationDriver.java
+++ b/bundles/org.palladiosimulator.analyzer.slingshot.core/src/org/palladiosimulator/analyzer/slingshot/core/api/SimulationDriver.java
@@ -1,11 +1,15 @@
 package org.palladiosimulator.analyzer.slingshot.core.api;
 
+import java.util.function.Function;
+
 import org.eclipse.core.runtime.IProgressMonitor;
+import org.palladiosimulator.analyzer.slingshot.core.extension.SimulationBehaviorExtension;
+import org.palladiosimulator.analyzer.slingshot.eventdriver.returntypes.Result;
 import org.palladiosimulator.analyzer.workflow.blackboard.PCMResourceSetPartition;
 
 import de.uka.ipd.sdq.simucomframework.SimuComConfig;
 
-public interface SimulationDriver extends SimulationScheduling {
+public interface SimulationDriver extends SimulationScheduling, BusBasedDriver {
 	
 	public void init(final SimuComConfig config, final IProgressMonitor monitor);
 	

--- a/bundles/org.palladiosimulator.analyzer.slingshot.core/src/org/palladiosimulator/analyzer/slingshot/core/api/SimulationEngine.java
+++ b/bundles/org.palladiosimulator.analyzer.slingshot.core/src/org/palladiosimulator/analyzer/slingshot/core/api/SimulationEngine.java
@@ -5,6 +5,7 @@ import java.util.function.Function;
 import org.palladiosimulator.analyzer.slingshot.common.events.DESEvent;
 import org.palladiosimulator.analyzer.slingshot.common.events.SlingshotEvent;
 import org.palladiosimulator.analyzer.slingshot.core.extension.SimulationBehaviorExtension;
+import org.palladiosimulator.analyzer.slingshot.eventdriver.returntypes.Result;
 
 public interface SimulationEngine {
 	
@@ -24,5 +25,7 @@ public interface SimulationEngine {
 	
 	public void registerEventListener(final SimulationBehaviorExtension guavaEventClass);
 	
-	
+	public <T> void registerEventListener(final Class<T> forEvent, final Function<T, Result<?>> handler);
+
+
 }

--- a/bundles/org.palladiosimulator.analyzer.slingshot.core/src/org/palladiosimulator/analyzer/slingshot/core/api/SimulationEngine.java
+++ b/bundles/org.palladiosimulator.analyzer.slingshot.core/src/org/palladiosimulator/analyzer/slingshot/core/api/SimulationEngine.java
@@ -1,12 +1,20 @@
 package org.palladiosimulator.analyzer.slingshot.core.api;
 
+import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 import org.palladiosimulator.analyzer.slingshot.common.events.DESEvent;
 import org.palladiosimulator.analyzer.slingshot.common.events.SlingshotEvent;
 import org.palladiosimulator.analyzer.slingshot.core.extension.SimulationBehaviorExtension;
 import org.palladiosimulator.analyzer.slingshot.eventdriver.returntypes.Result;
 
+/**
+ * An abstraction for an engine (for example, SSJ) that handles the events
+ * within the simulation.
+ * 
+ * @author Julijan Katic
+ */
 public interface SimulationEngine {
 	
 	public void init();
@@ -19,13 +27,6 @@ public interface SimulationEngine {
 	
 	public boolean isRunning();
 	
-	public void scheduleEvent(final DESEvent event);
+	public void schedule(final DESEvent event, final Consumer<DESEvent> onDispatch);
 	
-	public void scheduleEventAt(final DESEvent event, final double simulationTime);
-	
-	public void registerEventListener(final SimulationBehaviorExtension guavaEventClass);
-	
-	public <T> void registerEventListener(final Class<T> forEvent, final Function<T, Result<?>> handler);
-
-
 }

--- a/bundles/org.palladiosimulator.analyzer.slingshot.core/src/org/palladiosimulator/analyzer/slingshot/core/api/SimulationEngineEvent.java
+++ b/bundles/org.palladiosimulator.analyzer.slingshot.core/src/org/palladiosimulator/analyzer/slingshot/core/api/SimulationEngineEvent.java
@@ -1,0 +1,44 @@
+package org.palladiosimulator.analyzer.slingshot.core.api;
+
+import java.util.Objects;
+
+import org.palladiosimulator.analyzer.slingshot.common.events.DESEvent;
+
+public abstract class SimulationEngineEvent {
+
+	/** 
+	 * Tells to simulate at the next possible event. That is,
+	 * the engine should simply put the event at the next
+	 * possible time-frame after the delay.
+	 */
+	public static final double SIMULATE_NEXT = -1;
+	
+	private final DESEvent event;
+	private final double simulateAt;
+	private final double delay;
+	
+	protected SimulationEngineEvent(final DESEvent event) {
+		this.event = Objects.requireNonNull(event);
+		this.simulateAt = event.time();
+		this.delay = event.delay();
+	}
+	
+	/**
+	 * A handler for the engine when an engine's event is happening.
+	 */
+	public abstract void onEvent();
+
+	public DESEvent getEvent() {
+		return event;
+	}
+
+	public double getSimulateAt() {
+		return simulateAt;
+	}
+
+	public double getDelay() {
+		return delay;
+	}
+	
+	
+}

--- a/bundles/org.palladiosimulator.analyzer.slingshot.core/src/org/palladiosimulator/analyzer/slingshot/core/api/SystemDriver.java
+++ b/bundles/org.palladiosimulator.analyzer.slingshot.core/src/org/palladiosimulator/analyzer/slingshot/core/api/SystemDriver.java
@@ -5,7 +5,7 @@ import java.util.function.Consumer;
 import org.palladiosimulator.analyzer.slingshot.common.events.SystemEvent;
 import org.palladiosimulator.analyzer.slingshot.eventdriver.returntypes.Result;
 
-public interface SystemDriver {
+public interface SystemDriver extends BusBasedDriver {
 
 	void postEvent(final SystemEvent systemEvent);
 	

--- a/bundles/org.palladiosimulator.analyzer.slingshot.core/src/org/palladiosimulator/analyzer/slingshot/core/driver/SlingshotSimulationDriver.java
+++ b/bundles/org.palladiosimulator.analyzer.slingshot.core/src/org/palladiosimulator/analyzer/slingshot/core/driver/SlingshotSimulationDriver.java
@@ -2,6 +2,7 @@ package org.palladiosimulator.analyzer.slingshot.core.driver;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import javax.inject.Singleton;
@@ -19,6 +20,7 @@ import org.palladiosimulator.analyzer.slingshot.core.events.SimulationFinished;
 import org.palladiosimulator.analyzer.slingshot.core.events.SimulationStarted;
 import org.palladiosimulator.analyzer.slingshot.core.extension.AbstractSlingshotExtension;
 import org.palladiosimulator.analyzer.slingshot.core.extension.SystemBehaviorContainer;
+import org.palladiosimulator.analyzer.slingshot.eventdriver.returntypes.Result;
 import org.palladiosimulator.analyzer.slingshot.core.extension.ExtensionIds;
 import org.palladiosimulator.analyzer.slingshot.core.extension.SimulationBehaviorContainer;
 import org.palladiosimulator.analyzer.slingshot.core.extension.SimulationBehaviorExtension;
@@ -135,6 +137,16 @@ public class SlingshotSimulationDriver implements SimulationDriver {
 		this.engine.scheduleEventAt(event, simulationTime);
 	}
 	
+	@Override
+	public void registerHandlers(SimulationBehaviorExtension handlers) {
+		this.engine.registerEventListener(handlers);
+	}
+
+	@Override
+	public <T> void registerHandler(String id, Class<T> forEvent, Function<T, Result<?>> handler) {
+		this.engine.registerEventListener(forEvent, handler);
+	}
+	
 	private static class SimulationDriverSubModule extends AbstractModule {
 		
 		private final IProgressMonitor monitor;
@@ -158,4 +170,5 @@ public class SlingshotSimulationDriver implements SimulationDriver {
 		//	return this.config;
 		//}
 	}
+
 }

--- a/bundles/org.palladiosimulator.analyzer.slingshot.core/src/org/palladiosimulator/analyzer/slingshot/core/driver/SlingshotSystemDriver.java
+++ b/bundles/org.palladiosimulator.analyzer.slingshot.core/src/org/palladiosimulator/analyzer/slingshot/core/driver/SlingshotSystemDriver.java
@@ -78,7 +78,7 @@ public class SlingshotSystemDriver implements SystemDriver {
 
 	@Override
 	public <T> void registerHandler(String id, Class<T> forEvent, Function<T, Result<?>> handler) {
-		this.systemBus.registerHandler(forEvent, handler);
+		this.systemBus.registerHandler(id, forEvent, handler);
 	}
 	
 }

--- a/bundles/org.palladiosimulator.analyzer.slingshot.core/src/org/palladiosimulator/analyzer/slingshot/core/driver/SlingshotSystemDriver.java
+++ b/bundles/org.palladiosimulator.analyzer.slingshot.core/src/org/palladiosimulator/analyzer/slingshot/core/driver/SlingshotSystemDriver.java
@@ -1,6 +1,7 @@
 package org.palladiosimulator.analyzer.slingshot.core.driver;
 
 import java.util.List;
+import java.util.function.Function;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -13,6 +14,7 @@ import org.palladiosimulator.analyzer.slingshot.core.extension.SystemBehaviorCon
 import org.palladiosimulator.analyzer.slingshot.core.extension.SimulationBehaviorExtension;
 import org.palladiosimulator.analyzer.slingshot.core.extension.SystemBehaviorExtension;
 import org.palladiosimulator.analyzer.slingshot.eventdriver.Bus;
+import org.palladiosimulator.analyzer.slingshot.eventdriver.returntypes.Result;
 
 import com.google.inject.Injector;
 
@@ -67,6 +69,16 @@ public class SlingshotSystemDriver implements SystemDriver {
 	@Override
 	public boolean isRunning() {
 		return this.running;
+	}
+
+	@Override
+	public void registerHandlers(SimulationBehaviorExtension handlers) {
+		this.systemBus.register(handlers);
+	}
+
+	@Override
+	public <T> void registerHandler(String id, Class<T> forEvent, Function<T, Result<?>> handler) {
+		this.systemBus.registerHandler(forEvent, handler);
 	}
 	
 }

--- a/bundles/org.palladiosimulator.analyzer.slingshot.core/src/org/palladiosimulator/analyzer/slingshot/core/engine/SimulationEngineSSJ.java
+++ b/bundles/org.palladiosimulator.analyzer.slingshot.core/src/org/palladiosimulator/analyzer/slingshot/core/engine/SimulationEngineSSJ.java
@@ -2,6 +2,8 @@ package org.palladiosimulator.analyzer.slingshot.core.engine;
 
 import org.apache.log4j.Logger;
 
+import java.util.function.Function;
+
 import javax.inject.Singleton;
 
 import org.apache.log4j.LogManager;
@@ -10,6 +12,7 @@ import org.palladiosimulator.analyzer.slingshot.core.api.SimulationEngine;
 import org.palladiosimulator.analyzer.slingshot.core.api.SimulationInformation;
 import org.palladiosimulator.analyzer.slingshot.core.extension.SimulationBehaviorExtension;
 import org.palladiosimulator.analyzer.slingshot.eventdriver.Bus;
+import org.palladiosimulator.analyzer.slingshot.eventdriver.returntypes.Result;
 
 import umontreal.ssj.simevents.Event;
 import umontreal.ssj.simevents.Simulator;
@@ -120,4 +123,8 @@ public class SimulationEngineSSJ implements SimulationEngine, SimulationInformat
 		this.eventBus.register(guavaEventClass);
 	}
 
+	@Override
+	public <T> void registerEventListener(final Class<T> forEvent, final Function<T, Result<?>> handler) {
+		this.eventBus.registerHandler(forEvent, handler);
+	}
 }

--- a/bundles/org.palladiosimulator.analyzer.slingshot.eventdriver/src/org/palladiosimulator/analyzer/slingshot/eventdriver/Bus.java
+++ b/bundles/org.palladiosimulator.analyzer.slingshot.eventdriver/src/org/palladiosimulator/analyzer/slingshot/eventdriver/Bus.java
@@ -35,10 +35,15 @@ public interface Bus {
 	 * The most generic registration of an event handler, where an own type of subscriber can be added.
 	 * 
 	 * @param <T> The type of the event.
+	 * @param id An object that can be used as an Identifier, for example a unique string or the object
+	 * 			 itself containing subscribers.
 	 * @param forEvent
 	 * @param subscriber
 	 */
-	public <T> void registerSubscriber(final Class<T> forEvent, final AbstractSubscriber<T> subscriber);
+	public <T> void registerSubscriber(
+			final Object id,
+			final Class<T> forEvent,
+			final AbstractSubscriber<T> subscriber);
 	
 	/**
 	 * Registers a new object as an {@link AnnotatedSubscriber} and adds the possibility to register
@@ -55,10 +60,15 @@ public interface Bus {
 	 * Registers a new event handler directly to the system as a {@link LambdaBasedSubscriber}.
 	 * 
 	 * @param <T> The type of the event to listen to.
+	 * @param id An identifier for this handler.
 	 * @param forEvent The event type as a {@code Class}.
 	 * @param handler The function to register as the event's subscriber.
+	 * @see #registerSubscriber(Object, Class, AbstractSubscriber)
 	 */
-	public <T> void registerHandler(final Class<T> forEvent, final Function<T, ? extends Result<?>> handler);
+	public <T> void registerHandler(
+			final Object id,
+			final Class<T> forEvent, 
+			final Function<T, ? extends Result<?>> handler);
 	
 	/**
 	 * Unregisters an object containing subscribers. Every subscriber inside will be ignored from now on.

--- a/bundles/org.palladiosimulator.analyzer.slingshot.eventdriver/src/org/palladiosimulator/analyzer/slingshot/eventdriver/Bus.java
+++ b/bundles/org.palladiosimulator.analyzer.slingshot.eventdriver/src/org/palladiosimulator/analyzer/slingshot/eventdriver/Bus.java
@@ -1,16 +1,94 @@
 package org.palladiosimulator.analyzer.slingshot.eventdriver;
 
-import org.palladiosimulator.analyzer.slingshot.eventdriver.internal.BusImplementation;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.function.Function;
 
+import org.palladiosimulator.analyzer.slingshot.eventdriver.entity.AbstractSubscriber;
+import org.palladiosimulator.analyzer.slingshot.eventdriver.entity.interceptors.IPostInterceptor;
+import org.palladiosimulator.analyzer.slingshot.eventdriver.entity.interceptors.IPreInterceptor;
+import org.palladiosimulator.analyzer.slingshot.eventdriver.internal.BusImplementation;
+import org.palladiosimulator.analyzer.slingshot.eventdriver.returntypes.Result;
+
+/**
+ * A general Bus interface that can handle events of any type, and allows adding subscribers
+ * to events.
+ * 
+ * The subscribers themselves can be arbitrarily defined, and need to inherit from {@link AbstractSubscriber}.
+ * The most used subscription type is the {@link AnnotatedSubscriber}, but it is also possible
+ * to and subscribers in a functional style using {@link LambdaBasedSubscriber}.
+ * 
+ * Each bus has an identifier for logging purposes. It can either be generated or provided by the user.
+ * 
+ * @author Julijan Katic
+ * @version 2023-01-24
+ */
 public interface Bus {
 
+	/**
+	 * The unique identifer of this bus. This can be generated or provided by the user.
+	 * @return The unique identifier.
+	 */
 	public String getIdentifier();
 	
+	/**
+	 * The most generic registration of an event handler, where an own type of subscriber can be added.
+	 * 
+	 * @param <T> The type of the event.
+	 * @param forEvent
+	 * @param subscriber
+	 */
+	public <T> void registerSubscriber(final Class<T> forEvent, final AbstractSubscriber<T> subscriber);
+	
+	/**
+	 * Registers a new object as an {@link AnnotatedSubscriber} and adds the possibility to register
+	 * each of its method as a subscriber, interceptor or error-handler. This is the most common
+	 * form of event subscription.
+	 * 
+	 * To add a functional subscriber, see {@link #registerHandler}.
+	 * 
+	 * @param object The object whose methods should be registered that are appropriately annotated.
+	 */
 	public void register(final Object object);
 	
+	/**
+	 * Registers a new event handler directly to the system as a {@link LambdaBasedSubscriber}.
+	 * 
+	 * @param <T> The type of the event to listen to.
+	 * @param forEvent The event type as a {@code Class}.
+	 * @param handler The function to register as the event's subscriber.
+	 */
+	public <T> void registerHandler(final Class<T> forEvent, final Function<T, ? extends Result<?>> handler);
+	
+	/**
+	 * Unregisters an object containing subscribers. Every subscriber inside will be ignored from now on.
+	 * 
+	 * @param object The object to unregister.
+	 */
 	public void unregister(final Object object);
 	
+	/**
+	 * Adds a pre interceptor.
+	 * @param preInterceptor
+	 */
+	public void addPreInterceptor(final Class<?> forEvent, final IPreInterceptor preInterceptor);
+	
+	public void addPostInterceptor(final Class<?> forEvent, final IPostInterceptor postInterceptor);
+	
+	public <T extends Throwable> void addExceptionHandler(final Class<T> onException, final Consumer<T> exceptionHandler);
+	
+	/**
+	 * Posts an event and calls each handler that are subscribed to, if the interceptors allow that.
+	 * 
+	 * @param event The event to post.
+	 */
 	public void post(final Object event);
+
+	public void closeRegistration();
+	
+	public void acceptEvents(final boolean accept);
+	
+	public void clear();
 	
 	public static Bus instance() {
 		return new BusImplementation();
@@ -19,8 +97,4 @@ public interface Bus {
 	public static Bus instance(final String name) {
 		return new BusImplementation(name);
 	}
-
-	public void closeRegistration();
-	
-	public void acceptEvents(final boolean accept);
 }

--- a/bundles/org.palladiosimulator.analyzer.slingshot.eventdriver/src/org/palladiosimulator/analyzer/slingshot/eventdriver/entity/AbstractSubscriber.java
+++ b/bundles/org.palladiosimulator.analyzer.slingshot.eventdriver/src/org/palladiosimulator/analyzer/slingshot/eventdriver/entity/AbstractSubscriber.java
@@ -1,24 +1,63 @@
 package org.palladiosimulator.analyzer.slingshot.eventdriver.entity;
 
+import java.util.Optional;
+
 import org.palladiosimulator.analyzer.slingshot.eventdriver.annotations.Subscribe;
+import org.palladiosimulator.analyzer.slingshot.eventdriver.entity.interceptors.IPostInterceptor;
+import org.palladiosimulator.analyzer.slingshot.eventdriver.entity.interceptors.IPreInterceptor;
+import org.palladiosimulator.analyzer.slingshot.eventdriver.entity.interceptors.InterceptorInformation;
+import org.palladiosimulator.analyzer.slingshot.eventdriver.returntypes.InterceptionResult;
+import org.palladiosimulator.analyzer.slingshot.eventdriver.returntypes.Result;
 
 import io.reactivex.rxjava3.disposables.Disposable;
 import io.reactivex.rxjava3.functions.Consumer;
 
+/**
+ * 
+ * @author julijankatic
+ *
+ * @param <T> The "events" or "messages" it allows.
+ */
 public abstract class AbstractSubscriber<T> implements Consumer<T>, Disposable, Comparable<AbstractSubscriber<T>> {
 	
 	private boolean disposed = false;
 	private final int priority;
 	private final Class<?>[] reifiedClasses;
+
+	private final Optional<IPreInterceptor> preInterceptor;
+	private final Optional<IPostInterceptor> postInterceptor;
 	
-	public AbstractSubscriber(final Subscribe subscriberAnnotation) {
-		this.priority = subscriberAnnotation.priority();
-		this.reifiedClasses = subscriberAnnotation.reified();
+
+	public AbstractSubscriber(int priority, Class<?>[] reifiedClasses, final IPreInterceptor preInterceptor,
+			final IPostInterceptor postInterceptor) {
+		super();
+		this.priority = priority;
+		this.reifiedClasses = reifiedClasses;
+		this.preInterceptor = Optional.ofNullable(preInterceptor);
+		this.postInterceptor = Optional.ofNullable(postInterceptor);
 	}
-	
+
 	@Override
 	public void accept(final T event) throws Exception {
-		this.acceptEvent(event);
+		final InterceptorInformation preInterceptionInformation = getInterceptorInformation();
+		
+		final InterceptionResult preInterceptionResult = this.preInterceptor
+				.map(preInterceptor -> preInterceptor.apply(preInterceptionInformation, event))
+				.orElseGet(() -> InterceptionResult.success());
+		
+		if (!this.checkIfCorrectlyReified(event)) {
+			return;
+		}
+		
+		if (!preInterceptionResult.wasSuccessful()) {
+			return;
+		}
+		
+		final Result<?> result = this.acceptEvent(event);
+		
+		final InterceptionResult postInterceptionResult = this.postInterceptor
+				.map(postInterceptor -> postInterceptor.apply(preInterceptionInformation, event, result))
+				.orElseGet(() -> InterceptionResult.success());
 	}
 	
 	@Override
@@ -34,9 +73,11 @@ public abstract class AbstractSubscriber<T> implements Consumer<T>, Disposable, 
 		return this.disposed;
 	}
 	
-	protected abstract void acceptEvent(final T event) throws Exception;
+	protected abstract Result<?> acceptEvent(final T event) throws Exception;
 	
 	protected abstract void release();
+	
+	protected abstract InterceptorInformation getInterceptorInformation();
 	
 	@Override
 	public int compareTo(final AbstractSubscriber<T> other) {
@@ -49,5 +90,19 @@ public abstract class AbstractSubscriber<T> implements Consumer<T>, Disposable, 
 	
 	public Class<?>[] getReifiedClasses() {
 		return this.reifiedClasses;
+	}
+	
+	private boolean checkIfCorrectlyReified(final Object event) {
+		if (event instanceof ReifiedEvent<?>) {
+			if (this.getReifiedClasses() == null || this.getReifiedClasses().length == 0) {
+				// We always accept then
+				return true;
+			}
+			
+			final ReifiedEvent<?> reifiedEvent = (ReifiedEvent<?>) event;
+			return this.getReifiedClasses()[0].isAssignableFrom(reifiedEvent.getTypeToken().getRawType());
+		}
+		// Since it's not a reified event, check is not needed.
+		return true;
 	}
 }

--- a/bundles/org.palladiosimulator.analyzer.slingshot.eventdriver/src/org/palladiosimulator/analyzer/slingshot/eventdriver/entity/AnnotatedSubscriber.java
+++ b/bundles/org.palladiosimulator.analyzer.slingshot.eventdriver/src/org/palladiosimulator/analyzer/slingshot/eventdriver/entity/AnnotatedSubscriber.java
@@ -17,74 +17,45 @@ public final class AnnotatedSubscriber extends AbstractSubscriber<Object> {
 
 	private final Method method;
 	private final Object target;
-	private final Optional<IPreInterceptor> preInterceptor;
-	private final Optional<IPostInterceptor> postInterceptor;
 	private final Class<?> resultType;
 	
 	public AnnotatedSubscriber(final Method method, final Object target, 
 			final IPreInterceptor preInterceptor,
 			final IPostInterceptor postInterceptor,
 			final Subscribe subscriberAnnotation) {
-		super(subscriberAnnotation);
+		super(subscriberAnnotation.priority(), subscriberAnnotation.reified(), preInterceptor, postInterceptor);
 		this.method = Objects.requireNonNull(method);
 		this.target = Objects.requireNonNull(target);
-		this.preInterceptor = Optional.ofNullable(preInterceptor);
-		this.postInterceptor = Optional.ofNullable(postInterceptor);
 		this.resultType = method.getReturnType();
 	}
 
 	@Override
-	protected void acceptEvent(Object event) throws Exception {
-		final InterceptorInformation preInterceptionInformation = new InterceptorInformation(target, method);
+	protected Result<?> acceptEvent(Object event) throws Exception {
+	
+		final Result<?> result;
 		
-		final InterceptionResult preInterceptionResult = this.preInterceptor
-				.map(preInterceptor -> preInterceptor.apply(preInterceptionInformation, event))
-				.orElseGet(() -> InterceptionResult.success());
-		
-		if (!this.checkIfCorrectlyReified(event)) {
-			return;
-		}
-		
-		final Result result;
-		if (preInterceptionResult.wasSuccessful()) {
-			
-			try {
-				if (resultType.equals(void.class) || resultType.equals(Void.class)) {
-					// Return type void is equivalent to Result.empty()
-					result = Result.empty();
-					this.method.invoke(target, event);
-				} else {
-					result = (Result) this.method.invoke(target, event);
-				}
-			} catch (final InvocationTargetException ex) {
-				if (ex.getCause() != null && ex.getCause() instanceof Exception) {
-					throw (Exception) ex.getCause();
-				}
-				return;
+		try {
+			if (resultType.equals(void.class) || resultType.equals(Void.class)) {
+				// Return type void is equivalent to Result.empty()
+				result = Result.empty();
+				this.method.invoke(target, event);
+			} else {
+				result = (Result) this.method.invoke(target, event);
 			}
-			
-		} else {
-			result = Result.empty();
+		} catch (final InvocationTargetException ex) {
+			if (ex.getCause() != null && ex.getCause() instanceof Exception) {
+				throw (Exception) ex.getCause();
+			}
+			return Result.empty(); // TODO: Look at this
 		}
 		
-		final InterceptionResult postInterceptionResult = this.postInterceptor
-				.map(postInterceptor -> postInterceptor.apply(preInterceptionInformation, event, result))
-				.orElseGet(() -> InterceptionResult.success());
+		return result;
 		
 	}
 	
-	private boolean checkIfCorrectlyReified(final Object event) {
-		if (event instanceof ReifiedEvent<?>) {
-			if (this.getReifiedClasses() == null || this.getReifiedClasses().length == 0) {
-				// We always accept then
-				return true;
-			}
-			
-			final ReifiedEvent<?> reifiedEvent = (ReifiedEvent<?>) event;
-			return this.getReifiedClasses()[0].isAssignableFrom(reifiedEvent.getTypeToken().getRawType());
-		}
-		// Since it's not a reified event, check is not needed.
-		return true;
+	@Override
+	protected InterceptorInformation getInterceptorInformation() {
+		return new InterceptorInformation(target, method);
 	}
 
 	@Override

--- a/bundles/org.palladiosimulator.analyzer.slingshot.eventdriver/src/org/palladiosimulator/analyzer/slingshot/eventdriver/entity/LambdaBasedSubscriber.java
+++ b/bundles/org.palladiosimulator.analyzer.slingshot.eventdriver/src/org/palladiosimulator/analyzer/slingshot/eventdriver/entity/LambdaBasedSubscriber.java
@@ -1,0 +1,39 @@
+package org.palladiosimulator.analyzer.slingshot.eventdriver.entity;
+
+import java.util.Objects;
+import java.util.function.Function;
+
+import org.palladiosimulator.analyzer.slingshot.eventdriver.entity.interceptors.IPostInterceptor;
+import org.palladiosimulator.analyzer.slingshot.eventdriver.entity.interceptors.IPreInterceptor;
+import org.palladiosimulator.analyzer.slingshot.eventdriver.entity.interceptors.InterceptorInformation;
+import org.palladiosimulator.analyzer.slingshot.eventdriver.returntypes.Result;
+
+public final class LambdaBasedSubscriber<T> extends AbstractSubscriber<T> {
+
+	private final Function<? super T, ? extends Result<?>> handler;
+	
+	public LambdaBasedSubscriber(
+			final int priority, 
+			final Class<?>[] reifiedClasses,
+			final IPreInterceptor preInterceptor,
+			final IPostInterceptor postInterceptor,
+			final Function<? super T, ? extends Result<?>> handler) {
+		super(priority, reifiedClasses, preInterceptor, postInterceptor);
+		this.handler = Objects.requireNonNull(handler, "A handler must not be null!");
+	}
+
+	@Override
+	protected Result<?> acceptEvent(T event) throws Exception {
+		return handler.apply(event);
+	}
+
+	@Override
+	protected void release() {
+		// Do nothing
+	}
+	
+	@Override
+	protected InterceptorInformation getInterceptorInformation() {
+		return null; // TODO
+	}
+}

--- a/bundles/org.palladiosimulator.analyzer.slingshot.eventdriver/src/org/palladiosimulator/analyzer/slingshot/eventdriver/entity/interceptors/IPostInterceptor.java
+++ b/bundles/org.palladiosimulator.analyzer.slingshot.eventdriver/src/org/palladiosimulator/analyzer/slingshot/eventdriver/entity/interceptors/IPostInterceptor.java
@@ -3,6 +3,7 @@ package org.palladiosimulator.analyzer.slingshot.eventdriver.entity.interceptors
 import org.palladiosimulator.analyzer.slingshot.eventdriver.returntypes.InterceptionResult;
 import org.palladiosimulator.analyzer.slingshot.eventdriver.returntypes.Result;
 
+@FunctionalInterface
 public interface IPostInterceptor {
 
 	public InterceptionResult apply(final InterceptorInformation inf, final Object event, final Result result);

--- a/bundles/org.palladiosimulator.analyzer.slingshot.eventdriver/src/org/palladiosimulator/analyzer/slingshot/eventdriver/entity/interceptors/IPreInterceptor.java
+++ b/bundles/org.palladiosimulator.analyzer.slingshot.eventdriver/src/org/palladiosimulator/analyzer/slingshot/eventdriver/entity/interceptors/IPreInterceptor.java
@@ -4,6 +4,7 @@ import org.palladiosimulator.analyzer.slingshot.eventdriver.returntypes.Intercep
 
 import io.reactivex.rxjava3.functions.BiFunction;
 
+@FunctionalInterface
 public interface IPreInterceptor {
 	
 	public InterceptionResult apply(final InterceptorInformation preInterceptorInformation, final Object event);

--- a/tests/org.palladiosimulator.analyzer.slingshot.eventdriver.test/src/org/palladiosimulator/analyzer/slingshot/eventdriver/BusTestDynamicHandlers.java
+++ b/tests/org.palladiosimulator.analyzer.slingshot.eventdriver.test/src/org/palladiosimulator/analyzer/slingshot/eventdriver/BusTestDynamicHandlers.java
@@ -20,7 +20,7 @@ public class BusTestDynamicHandlers {
 	
 	@Test
 	public void testCheckIfHandlerExist() {
-		bus.registerHandler(SomeEvent.class, event -> {
+		bus.registerHandler("test", SomeEvent.class, event -> {
 			hasWorked = true;
 			return Result.empty();
 		});

--- a/tests/org.palladiosimulator.analyzer.slingshot.eventdriver.test/src/org/palladiosimulator/analyzer/slingshot/eventdriver/BusTestDynamicHandlers.java
+++ b/tests/org.palladiosimulator.analyzer.slingshot.eventdriver.test/src/org/palladiosimulator/analyzer/slingshot/eventdriver/BusTestDynamicHandlers.java
@@ -1,0 +1,32 @@
+package org.palladiosimulator.analyzer.slingshot.eventdriver;
+
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.palladiosimulator.analyzer.slingshot.eventdriver.returntypes.Result;
+
+public class BusTestDynamicHandlers {
+
+	private final Bus bus = Bus.instance("test");
+	private boolean hasWorked;
+	
+	@BeforeEach
+	public void init() {
+		this.hasWorked = false;
+	}
+	
+	@Test
+	public void testCheckIfHandlerExist() {
+		bus.registerHandler(SomeEvent.class, event -> {
+			hasWorked = true;
+			return Result.empty();
+		});
+		bus.post(new SomeEvent());
+		assertTrue(hasWorked);
+	}
+	
+	public static final class SomeEvent {}
+}


### PR DESCRIPTION
Added a mechanism to add new event handlers **during runtime**.

For example, one is able to retrieve the `SimulationDriver` instance and then do the following if needed:
```java
simulationDriver.registerHandler("Some identifier", SomeEvent.class, someEvent -> {
   LOGGER.info("Do something");
   return Result.of(new NewEvent());
});
```
It registers a new event handler for the event `SomeEvent` and also assigns a string-based id, which can later be used to e.g. unregister this handler again.

The only thing that is missing right now is adding new contracts during runtime (since it is not possible to add new annotations at runtime).