### PR TITLE
Multiple simulation runs with more child injectors

### DIFF
--- a/bundles/org.palladiosimulator.analyzer.slingshot.core/src/org/palladiosimulator/analyzer/slingshot/core/SimulationModule.java
+++ b/bundles/org.palladiosimulator.analyzer.slingshot.core/src/org/palladiosimulator/analyzer/slingshot/core/SimulationModule.java
@@ -1,0 +1,36 @@
+package org.palladiosimulator.analyzer.slingshot.core;
+
+import org.palladiosimulator.analyzer.slingshot.core.api.SimulationDriver;
+import org.palladiosimulator.analyzer.slingshot.core.api.SimulationEngine;
+import org.palladiosimulator.analyzer.slingshot.core.api.SimulationScheduling;
+import org.palladiosimulator.analyzer.slingshot.core.driver.SlingshotSimulationDriver;
+import org.palladiosimulator.analyzer.slingshot.core.engine.SimulationEngineSSJ;
+
+import com.google.inject.AbstractModule;
+
+/**
+ * Provides Simulation Run specific instances for simulation driver and engine.
+ *
+ * Explicit Bindings are necessary, or else the classes are bound in the parent.
+ * Bound at parent injector is a problem, because the classes should be {link
+ * {@link Singleton} for each Simulation run, not per Simulator instance.
+ *
+ * TODO : maybe we can pull some more injection related things from inside the simulation driver to up here.
+ *
+ * @author stiesssh
+ *
+ */
+public class SimulationModule extends AbstractModule {
+
+	@Override
+	protected void configure() {
+		// explicit bindings
+		bind(SimulationEngineSSJ.class);
+		bind(SlingshotSimulationDriver.class);
+
+		// linked binding
+		bind(SimulationDriver.class).to(SlingshotSimulationDriver.class);
+		bind(SimulationScheduling.class).to(SlingshotSimulationDriver.class);
+		bind(SimulationEngine.class).to(SimulationEngineSSJ.class);
+	}
+}

--- a/bundles/org.palladiosimulator.analyzer.slingshot.core/src/org/palladiosimulator/analyzer/slingshot/core/Slingshot.java
+++ b/bundles/org.palladiosimulator.analyzer.slingshot.core/src/org/palladiosimulator/analyzer/slingshot/core/Slingshot.java
@@ -20,6 +20,8 @@ import org.palladiosimulator.analyzer.slingshot.core.extension.AbstractSlingshot
 import org.palladiosimulator.analyzer.slingshot.core.extension.ExtensionIds;
 import org.palladiosimulator.commons.eclipseutils.ExtensionHelper;
 
+import com.google.inject.Injector;
+
 public class Slingshot extends Plugin {
 
 	private static final Logger LOGGER = LogManager.getLogger(Slingshot.class);
@@ -69,7 +71,10 @@ public class Slingshot extends Plugin {
 	}
 
 	public SimulationDriver getSimulationDriver() {
-		return injectionHolder.getInstance(SimulationDriver.class);
+		final Injector parent = this.injectionHolder.getInstance(Injector.class);
+		final Injector child = parent.createChildInjector(List.of(new SimulationModule()));
+
+		return child.getInstance(SimulationDriver.class);
 	}
 
 	public <T> T getInstance(final Class<T> clazz) {

--- a/bundles/org.palladiosimulator.analyzer.slingshot.core/src/org/palladiosimulator/analyzer/slingshot/core/Slingshot.java
+++ b/bundles/org.palladiosimulator.analyzer.slingshot.core/src/org/palladiosimulator/analyzer/slingshot/core/Slingshot.java
@@ -29,7 +29,7 @@ public class Slingshot extends Plugin {
 	private static Slingshot bundle = null;
 	private List<AbstractSlingshotExtension> extensions = null;
 
-	private InjectorHolder slingshotModule;
+	private InjectorHolder injectionHolder;
 
 	static {
 		setupLoggingLevelToDebug();
@@ -38,7 +38,7 @@ public class Slingshot extends Plugin {
 	@Override
 	public void start(final BundleContext context) throws Exception {
 		bundle = this;
-		this.slingshotModule = new InjectorHolder();
+		this.injectionHolder = new InjectorHolder();
 		LOGGER.debug("Slingshot started");
 		super.start(context);
 	}
@@ -47,7 +47,7 @@ public class Slingshot extends Plugin {
 	public void stop(final BundleContext context) throws Exception {
 		bundle = null;
 		this.extensions = null;
-		this.slingshotModule = null;
+		this.injectionHolder = null;
 		LOGGER.debug("Slingshot ended");
 		super.stop(context);
 	}
@@ -60,25 +60,24 @@ public class Slingshot extends Plugin {
 		return Collections.unmodifiableList(this.extensions);
 	}
 
-
 	public static Slingshot getInstance() {
 		return bundle;
 	}
 
 	public SystemDriver getSystemDriver() {
-		return slingshotModule.getInstance(SystemDriver.class); // TODO
+		return injectionHolder.getInstance(SystemDriver.class); // TODO
 	}
 
 	public SimulationDriver getSimulationDriver() {
-		return slingshotModule.getInstance(SimulationDriver.class);
+		return injectionHolder.getInstance(SimulationDriver.class);
 	}
 
 	public <T> T getInstance(final Class<T> clazz) {
-		return this.slingshotModule.getInstance(clazz);
+		return this.injectionHolder.getInstance(clazz);
 	}
 
 	public <T> Provider<T> getProvider(final Class<T> clazz) {
-		return this.slingshotModule.getProvider(clazz);
+		return this.injectionHolder.getProvider(clazz);
 	}
 
 	private static void setupLoggingLevelToDebug() {

--- a/bundles/org.palladiosimulator.analyzer.slingshot.core/src/org/palladiosimulator/analyzer/slingshot/core/SlingshotModule.java
+++ b/bundles/org.palladiosimulator.analyzer.slingshot.core/src/org/palladiosimulator/analyzer/slingshot/core/SlingshotModule.java
@@ -9,13 +9,8 @@ import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
 import org.palladiosimulator.analyzer.slingshot.core.annotations.SimulationBehaviorExtensions;
 import org.palladiosimulator.analyzer.slingshot.core.annotations.SystemBehaviorExtensions;
-import org.palladiosimulator.analyzer.slingshot.core.api.SimulationDriver;
-import org.palladiosimulator.analyzer.slingshot.core.api.SimulationEngine;
-import org.palladiosimulator.analyzer.slingshot.core.api.SimulationScheduling;
 import org.palladiosimulator.analyzer.slingshot.core.api.SystemDriver;
-import org.palladiosimulator.analyzer.slingshot.core.driver.SlingshotSimulationDriver;
 import org.palladiosimulator.analyzer.slingshot.core.driver.SlingshotSystemDriver;
-import org.palladiosimulator.analyzer.slingshot.core.engine.SimulationEngineSSJ;
 import org.palladiosimulator.analyzer.slingshot.core.extension.PCMResourceSetPartitionProvider;
 import org.palladiosimulator.analyzer.slingshot.core.extension.SimulationBehaviorContainer;
 import org.palladiosimulator.analyzer.slingshot.core.extension.SystemBehaviorContainer;
@@ -49,9 +44,6 @@ public class SlingshotModule extends AbstractModule {
 	@Override
 	protected void configure() {
 		bind(PCMResourceSetPartitionProvider.class);
-		bind(SimulationDriver.class).to(SlingshotSimulationDriver.class);
-		bind(SimulationScheduling.class).to(SlingshotSimulationDriver.class);
-		bind(SimulationEngine.class).to(SimulationEngineSSJ.class);
 		bind(SystemDriver.class).to(SlingshotSystemDriver.class);
 	}
 

--- a/bundles/org.palladiosimulator.analyzer.slingshot.core/src/org/palladiosimulator/analyzer/slingshot/core/api/SimulationEngine.java
+++ b/bundles/org.palladiosimulator.analyzer.slingshot.core/src/org/palladiosimulator/analyzer/slingshot/core/api/SimulationEngine.java
@@ -20,6 +20,4 @@ public interface SimulationEngine {
 	public void scheduleEventAt(final DESEvent event, final double simulationTime);
 
 	public void registerEventListener(final SimulationBehaviorExtension guavaEventClass);
-
-
 }

--- a/bundles/org.palladiosimulator.analyzer.slingshot.core/src/org/palladiosimulator/analyzer/slingshot/core/driver/SlingshotSimulationDriver.java
+++ b/bundles/org.palladiosimulator.analyzer.slingshot.core/src/org/palladiosimulator/analyzer/slingshot/core/driver/SlingshotSimulationDriver.java
@@ -63,13 +63,13 @@ public class SlingshotSimulationDriver implements SimulationDriver {
 		this.config = config;
 
 		behaviorContainers.stream()
-			.flatMap(extensions -> extensions.getExtensions().stream())
-			.forEach(simExtension -> {
-				final Object e = childInjector.getInstance(simExtension);
-				if (!(e instanceof SimulationBehaviorExtension)) {
+			.flatMap(behaviorContainer -> behaviorContainer.getExtensions().stream())
+			.forEach(simExtensionClass -> {
+				final Object simExtension = childInjector.getInstance(simExtensionClass);
+				if (!(simExtension instanceof SimulationBehaviorExtension)) {
 					return;
 				}
-				engine.registerEventListener((SimulationBehaviorExtension) e);
+				engine.registerEventListener((SimulationBehaviorExtension) simExtension);
 			});
 
 		engine.registerEventListener(new CoreBehavior(this));

--- a/bundles/org.palladiosimulator.analyzer.slingshot.core/src/org/palladiosimulator/analyzer/slingshot/core/driver/SlingshotSimulationDriver.java
+++ b/bundles/org.palladiosimulator.analyzer.slingshot.core/src/org/palladiosimulator/analyzer/slingshot/core/driver/SlingshotSimulationDriver.java
@@ -39,27 +39,25 @@ public class SlingshotSimulationDriver implements SimulationDriver {
 	private IProgressMonitor monitor;
 	private SimuComConfig config;
 
-	private Injector childInjector;
-
 	@Inject
-	public SlingshotSimulationDriver(final SimulationEngine engine,
-			final Injector injector,
+	public SlingshotSimulationDriver(final Injector injector, final SimulationEngine engine,
 			@SimulationBehaviorExtensions final List<SimulationBehaviorContainer> behaviorContainers) {
-		this.engine = engine;
 		this.parentInjector = injector;
 		this.behaviorContainers = behaviorContainers;
+		this.engine = engine;
 	}
 
 	@Override
 	public void init(final SimuComConfig config, final IProgressMonitor monitor) {
-		if (!this.initialized) {
+//		if (!this.initialized) {
 
 			final List<Module> partitionIncludedStream = new ArrayList<>(behaviorContainers.size() + 1);
-			partitionIncludedStream.add(new SimulationDriverSubModule(monitor, config));
+			partitionIncludedStream.add(new SimulationDriverSubModule(monitor));
 			partitionIncludedStream.addAll(behaviorContainers);
 
-			childInjector = this.parentInjector.createChildInjector(partitionIncludedStream);
-		}
+
+			 final Injector childInjector = this.parentInjector.createChildInjector(partitionIncludedStream);
+//		}
 
 		this.monitor = monitor;
 		this.config = config;
@@ -127,16 +125,18 @@ public class SlingshotSimulationDriver implements SimulationDriver {
 		this.engine.scheduleEventAt(event, simulationTime);
 	}
 
-	private static class SimulationDriverSubModule extends AbstractModule {
+
+	/**
+	 * Module to provide Simulation Run Specific Instances, that already exist, such
+	 * as the simuCom config and the progress monitor.
+	 *
+	 */
+	private class SimulationDriverSubModule extends AbstractModule {
 
 		private final IProgressMonitor monitor;
-		private final SimuComConfig config;
 
-		public SimulationDriverSubModule(final IProgressMonitor monitor,
-										 final SimuComConfig config) {
-		//	this.partition = partition;
+		public SimulationDriverSubModule(final IProgressMonitor monitor) {
 			this.monitor = monitor;
-			this.config = config;
 		}
 
 

--- a/bundles/org.palladiosimulator.analyzer.slingshot.core/src/org/palladiosimulator/analyzer/slingshot/core/driver/SlingshotSimulationDriver.java
+++ b/bundles/org.palladiosimulator.analyzer.slingshot.core/src/org/palladiosimulator/analyzer/slingshot/core/driver/SlingshotSimulationDriver.java
@@ -2,7 +2,6 @@ package org.palladiosimulator.analyzer.slingshot.core.driver;
 
 import java.util.ArrayList;
 import java.util.List;
-
 import javax.inject.Singleton;
 
 import org.eclipse.core.runtime.IProgressMonitor;
@@ -16,7 +15,6 @@ import org.palladiosimulator.analyzer.slingshot.core.events.SimulationFinished;
 import org.palladiosimulator.analyzer.slingshot.core.events.SimulationStarted;
 import org.palladiosimulator.analyzer.slingshot.core.extension.SimulationBehaviorContainer;
 import org.palladiosimulator.analyzer.slingshot.core.extension.SimulationBehaviorExtension;
-
 import com.google.inject.AbstractModule;
 import com.google.inject.Inject;
 import com.google.inject.Injector;
@@ -49,15 +47,13 @@ public class SlingshotSimulationDriver implements SimulationDriver {
 
 	@Override
 	public void init(final SimuComConfig config, final IProgressMonitor monitor) {
-//		if (!this.initialized) {
+		final List<Module> partitionIncludedStream = new ArrayList<>(behaviorContainers.size() + 2);
+		partitionIncludedStream.add(new SimulationDriverSubModule(monitor));
 
-			final List<Module> partitionIncludedStream = new ArrayList<>(behaviorContainers.size() + 1);
-			partitionIncludedStream.add(new SimulationDriverSubModule(monitor));
-			partitionIncludedStream.addAll(behaviorContainers);
+		partitionIncludedStream.addAll(behaviorContainers);
 
 
-			 final Injector childInjector = this.parentInjector.createChildInjector(partitionIncludedStream);
-//		}
+		final Injector childInjector = this.parentInjector.createChildInjector(partitionIncludedStream);
 
 		this.monitor = monitor;
 		this.config = config;
@@ -78,7 +74,7 @@ public class SlingshotSimulationDriver implements SimulationDriver {
 
 	@Override
 	public void start() {
-		if (this.isRunning()  || !this.initialized) {
+		if (this.isRunning() || !this.initialized) {
 			return;
 		}
 
@@ -106,7 +102,6 @@ public class SlingshotSimulationDriver implements SimulationDriver {
 		return this.running;
 	}
 
-
 	@Override
 	public void scheduleEvent(final DESEvent event) {
 		if (!this.isRunning()) {
@@ -125,7 +120,6 @@ public class SlingshotSimulationDriver implements SimulationDriver {
 		this.engine.scheduleEventAt(event, simulationTime);
 	}
 
-
 	/**
 	 * Module to provide Simulation Run Specific Instances, that already exist, such
 	 * as the simuCom config and the progress monitor.
@@ -139,15 +133,14 @@ public class SlingshotSimulationDriver implements SimulationDriver {
 			this.monitor = monitor;
 		}
 
-
 		@Provides
 		public IProgressMonitor monitor() {
 			return this.monitor;
 		}
 
-		//@Provides
-		//public SimuComConfig config() {
-		//	return this.config;
-		//}
+//		@Provides
+//		public SimuComConfig config() {
+//			return config;
+//		}
 	}
 }

--- a/bundles/org.palladiosimulator.analyzer.slingshot.core/src/org/palladiosimulator/analyzer/slingshot/core/driver/SlingshotSimulationDriver.java
+++ b/bundles/org.palladiosimulator.analyzer.slingshot.core/src/org/palladiosimulator/analyzer/slingshot/core/driver/SlingshotSimulationDriver.java
@@ -39,6 +39,8 @@ public class SlingshotSimulationDriver implements SimulationDriver {
 	private IProgressMonitor monitor;
 	private SimuComConfig config;
 
+	private Injector childInjector;
+
 	@Inject
 	public SlingshotSimulationDriver(final SimulationEngine engine,
 			final Injector injector,
@@ -50,19 +52,17 @@ public class SlingshotSimulationDriver implements SimulationDriver {
 
 	@Override
 	public void init(final SimuComConfig config, final IProgressMonitor monitor) {
-		if (this.initialized) {
-			return;
+		if (!this.initialized) {
+
+			final List<Module> partitionIncludedStream = new ArrayList<>(behaviorContainers.size() + 1);
+			partitionIncludedStream.add(new SimulationDriverSubModule(monitor, config));
+			partitionIncludedStream.addAll(behaviorContainers);
+
+			childInjector = this.parentInjector.createChildInjector(partitionIncludedStream);
 		}
+
 		this.monitor = monitor;
 		this.config = config;
-
-		final List<Module> partitionIncludedStream = new ArrayList<>(behaviorContainers.size() + 1);
-
-		partitionIncludedStream.add(new SimulationDriverSubModule(monitor, config));
-
-		partitionIncludedStream.addAll(behaviorContainers);
-
-		final Injector childInjector = this.parentInjector.createChildInjector(partitionIncludedStream);
 
 		behaviorContainers.stream()
 			.flatMap(extensions -> extensions.getExtensions().stream())

--- a/bundles/org.palladiosimulator.analyzer.slingshot.core/src/org/palladiosimulator/analyzer/slingshot/core/engine/SimulationEngineSSJ.java
+++ b/bundles/org.palladiosimulator.analyzer.slingshot.core/src/org/palladiosimulator/analyzer/slingshot/core/engine/SimulationEngineSSJ.java
@@ -19,7 +19,7 @@ public class SimulationEngineSSJ implements SimulationEngine, SimulationInformat
 
 	private final Logger LOGGER = LogManager.getLogger(SimulationEngineSSJ.class);
 
-	private Bus eventBus = Bus.instance();
+	private final Bus eventBus = Bus.instance();
 	private final Simulator simulator = new Simulator();
 
 	private int cumulativeEvents = 0;
@@ -74,7 +74,6 @@ public class SimulationEngineSSJ implements SimulationEngine, SimulationInformat
 		simulator.stop();
 		this.eventBus.acceptEvents(false);
 		this.isAcceptingEvents = false;
-		eventBus = Bus.instance(); // reset bus
 	}
 
 	@Override

--- a/bundles/org.palladiosimulator.analyzer.slingshot.core/src/org/palladiosimulator/analyzer/slingshot/core/extension/AbstractSlingshotExtension.java
+++ b/bundles/org.palladiosimulator.analyzer.slingshot.core/src/org/palladiosimulator/analyzer/slingshot/core/extension/AbstractSlingshotExtension.java
@@ -1,28 +1,65 @@
 package org.palladiosimulator.analyzer.slingshot.core.extension;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
 
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
 import org.eclipse.emf.ecore.EObject;
-
 import com.google.inject.AbstractModule;
+import com.google.inject.Provider;
 
 public abstract class AbstractSlingshotExtension extends AbstractModule {
 
+	private static final Logger LOGGER = LogManager.getLogger(AbstractSlingshotExtension.class);
+
 	private List<Class<?>> behaviorExtensions;
+
+	private Map<Class<?>, Class<? extends Provider<?>>> bindee2provider;
 
 	protected final void install(final Class<?> behaviorExtension) {
 		if (this.behaviorExtensions == null) {
 			this.behaviorExtensions = new LinkedList<>();
 		}
 
-		System.out.println("Installing " + behaviorExtension.getSimpleName());
-		this.behaviorExtensions.add(behaviorExtension);
+		if (!this.behaviorExtensions.contains(behaviorExtension)) {
+			LOGGER.debug(String.format("Installing %s.", behaviorExtension.getSimpleName()));
+			this.behaviorExtensions.add(behaviorExtension);
+		} else {
+			LOGGER.debug(String.format("Skip Installing %s, as it is already installed.",
+					behaviorExtension.getSimpleName()));
+		}
 	}
 
 	protected final <T extends EObject> void provideModel(final Class<T> model, final Class<? extends ModelProvider<T>> provider) {
 		bind(model).toProvider(provider);
+	}
+
+	protected final <T extends Object> void provideForDelay(final Class<T> bindee,
+			final Class<? extends Provider<T>> provider) {
+		if (this.bindee2provider == null) {
+			this.bindee2provider = new HashMap<>();
+		}
+
+		bindee2provider.put(bindee, provider);
+	}
+
+	public final <T> Map<Class<T>, Class<? extends Provider<T>>> getBindee2provider() {
+		final Map<Class<T>, Class<? extends Provider<T>>> rval = new HashMap<>();
+		if (this.bindee2provider != null) {
+			// somehow, i dont manage to cast the *entire* map at once.
+			for (final Entry<Class<?>, Class<? extends Provider<?>>> entry : this.bindee2provider.entrySet()) {
+				final Class<T> bindeee = (Class<T>) entry.getKey();
+				final Class<? extends Provider<T>> provider = (Class<? extends Provider<T>>) entry.getValue();
+
+				rval.put(bindeee, provider);
+			}
+		}
+		return rval;
 	}
 
 	@Override

--- a/bundles/org.palladiosimulator.analyzer.slingshot.core/src/org/palladiosimulator/analyzer/slingshot/core/extension/AbstractSlingshotExtension.java
+++ b/bundles/org.palladiosimulator.analyzer.slingshot.core/src/org/palladiosimulator/analyzer/slingshot/core/extension/AbstractSlingshotExtension.java
@@ -7,11 +7,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import javax.inject.Provider;
+
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
 import org.eclipse.emf.ecore.EObject;
 import com.google.inject.AbstractModule;
-import com.google.inject.Provider;
 
 public abstract class AbstractSlingshotExtension extends AbstractModule {
 
@@ -39,7 +40,7 @@ public abstract class AbstractSlingshotExtension extends AbstractModule {
 		bind(model).toProvider(provider);
 	}
 
-	protected final <T extends Object> void provideForDelay(final Class<T> bindee,
+	protected final <T extends Object> void install(final Class<T> bindee,
 			final Class<? extends Provider<T>> provider) {
 		if (this.bindee2provider == null) {
 			this.bindee2provider = new HashMap<>();

--- a/bundles/org.palladiosimulator.analyzer.slingshot.core/src/org/palladiosimulator/analyzer/slingshot/core/extension/ModelProvider.java
+++ b/bundles/org.palladiosimulator.analyzer.slingshot.core/src/org/palladiosimulator/analyzer/slingshot/core/extension/ModelProvider.java
@@ -1,8 +1,9 @@
 package org.palladiosimulator.analyzer.slingshot.core.extension;
 
+import javax.inject.Provider;
+
 import org.eclipse.emf.ecore.EObject;
 
-import com.google.inject.Provider;
 
 public interface ModelProvider<T extends EObject> extends Provider<T> {
 

--- a/bundles/org.palladiosimulator.analyzer.slingshot.core/src/org/palladiosimulator/analyzer/slingshot/core/extension/SimulationBehaviorContainer.java
+++ b/bundles/org.palladiosimulator.analyzer.slingshot.core/src/org/palladiosimulator/analyzer/slingshot/core/extension/SimulationBehaviorContainer.java
@@ -7,24 +7,27 @@ import com.google.inject.AbstractModule;
 
 public class SimulationBehaviorContainer extends AbstractModule {
 
-	private AbstractSlingshotExtension extension;
-	
+	private final AbstractSlingshotExtension extension;
+
 	public SimulationBehaviorContainer(final AbstractSlingshotExtension extension) {
 		this.extension = extension;
 	}
-	
+
 	@Override
 	public void configure() {
 		this.extension.getBehaviorExtensions().stream()
 			.filter(extension -> SimulationBehaviorExtension.class.isAssignableFrom(extension))
 			.forEach(this::bind);
+
+
+		this.extension.getBindee2provider().entrySet().stream().forEach(entry -> bind(entry.getKey()).toProvider(entry.getValue()));
 	}
-	
+
 	public List<Class<? extends SimulationBehaviorExtension>> getExtensions() {
 		return this.extension.getBehaviorExtensions().stream()
 				.filter(extension -> SimulationBehaviorExtension.class.isAssignableFrom(extension))
 				.map(extension -> (Class<? extends SimulationBehaviorExtension>) extension)
 				.collect(Collectors.toUnmodifiableList());
 	}
-	
+
 }

--- a/bundles/org.palladiosimulator.analyzer.slingshot.eventdriver/src/org/palladiosimulator/analyzer/slingshot/eventdriver/internal/BusImplementation.java
+++ b/bundles/org.palladiosimulator.analyzer.slingshot.eventdriver/src/org/palladiosimulator/analyzer/slingshot/eventdriver/internal/BusImplementation.java
@@ -79,7 +79,7 @@ public final class BusImplementation implements Bus {
 		final Class<?> observerClass = object.getClass();
 
 		if (observers.putIfAbsent(observerClass, new CompositeDisposable()) != null) {
-			throw new IllegalArgumentException("Observer has already been registered.");
+			throw new IllegalArgumentException(String.format("Cannot register observer %s : Observer has already been registered. ", observerClass.getSimpleName()));
 		}
 
 		final CompositeDisposable composite = observers.get(observerClass);

--- a/bundles/org.palladiosimulator.analyzer.slingshot.workflow/src/org/palladiosimulator/analyzer/slingshot/workflow/jobs/SimulationJob.java
+++ b/bundles/org.palladiosimulator.analyzer.slingshot.workflow/src/org/palladiosimulator/analyzer/slingshot/workflow/jobs/SimulationJob.java
@@ -36,10 +36,10 @@ public class SimulationJob implements IBlackboardInteractingJob<MDSDBlackboard> 
 		final PCMResourceSetPartition partition = (PCMResourceSetPartition)
 				this.blackboard.getPartition(ConstantsContainer.DEFAULT_PCM_INSTANCE_PARTITION_ID);
 
+		this.pcmResourceSetPartition.set(partition);
 		LOGGER.debug("Current partition: ");
 		partition.getResourceSet().getResources().forEach(resource -> LOGGER.debug("Resource: " + resource.getURI().path()));
 
-		this.pcmResourceSetPartition.set(partition);
 		LOGGER.debug("monitor: " + monitor.getClass().getName());
 		monitor.beginTask("Start Simulation", 3);
 


### PR DESCRIPTION
Replacement for PR #7.

Current behavior: Slingshot cannot execute multiple, successive simulation runs, among others because the models do not get updated.

New behavior: Slingshot can execute arbitrary many successive simulation runs on various models :)

#### Major Changes:
1. do *not* skip the `init` operation of `SlinghotSimulationDriver`.
  if we do not re-init the driver, the extensions are not recreated and the models already injected in the extensions are not updated and we cannot rerun on different models.
1. Add one additional level of childInjectors to inject a fresh Engine and Driver for each simulation run.  
prevents the atrocities i commited to the engine in PR #7.

1. add an operation to delay the binding to a provider. 
Instead of binding the `IGenericCalculatorFactory` and `ProbeFrameworkContext` when configuring the `MonitorModule`, save it and only acutally bind when configuring the respective container.
Cannot bind them directly (and system wide) because they need a `SimulationScheduling` which is after 2. above not available a system level

#### Minor Changes: 
* Some renames and improvements to error messages. 

### Misc 
related to https://github.com/PalladioSimulator/Palladio-Analyzer-Slingshot-Extension-Monitoring/pull/5.

if this is merged/rejected, the other PR should  be handled in accordance.