### PR TITLE
Added possibility to mark parameters as optional

### DIFF
--- a/bundles/org.palladiosimulator.analyzer.slingshot.common/META-INF/MANIFEST.MF
+++ b/bundles/org.palladiosimulator.analyzer.slingshot.common/META-INF/MANIFEST.MF
@@ -12,5 +12,6 @@ Require-Bundle: org.palladiosimulator.commons;bundle-version="5.1.0",
  com.google.guava;bundle-version="30.1.0",
  org.eclipse.emf.ecore,
  org.palladiosimulator.analyzer.slingshot.eventdriver
-Export-Package: org.palladiosimulator.analyzer.slingshot.common.events
+Export-Package: org.palladiosimulator.analyzer.slingshot.common.annotations,
+ org.palladiosimulator.analyzer.slingshot.common.events
 Import-Package: org.eclipse.emf.ecore.util

--- a/bundles/org.palladiosimulator.analyzer.slingshot.common/src/org/palladiosimulator/analyzer/slingshot/common/annotations/Nullable.java
+++ b/bundles/org.palladiosimulator.analyzer.slingshot.common/src/org/palladiosimulator/analyzer/slingshot/common/annotations/Nullable.java
@@ -1,0 +1,23 @@
+package org.palladiosimulator.analyzer.slingshot.common.annotations;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE_USE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * A Guice compatible annotation so that an injector allows {@code nulls}
+ * into constructors.
+ * 
+ * @author Julijan Katic
+ */
+@Documented
+@Retention(RUNTIME)
+@Target({ FIELD, PARAMETER, TYPE_USE })
+public @interface Nullable {
+
+}

--- a/bundles/org.palladiosimulator.analyzer.slingshot.core/src/org/palladiosimulator/analyzer/slingshot/core/driver/SlingshotSimulationDriver.java
+++ b/bundles/org.palladiosimulator.analyzer.slingshot.core/src/org/palladiosimulator/analyzer/slingshot/core/driver/SlingshotSimulationDriver.java
@@ -61,11 +61,14 @@ public class SlingshotSimulationDriver implements SimulationDriver {
 
 		behaviorContainers.stream().flatMap(behaviorContainer -> behaviorContainer.getExtensions().stream())
 				.forEach(simExtensionClass -> {
-					final Object simExtension = childInjector.getInstance(simExtensionClass);
-					if (!(simExtension instanceof SimulationBehaviorExtension)) {
+					final Object extension = childInjector.getInstance(simExtensionClass);
+					if (!(extension instanceof SimulationBehaviorExtension)) {
 						return;
 					}
-					engine.registerEventListener((SimulationBehaviorExtension) simExtension);
+					final SimulationBehaviorExtension simExtension = (SimulationBehaviorExtension) extension;
+					if (simExtension.isActive()) {
+						engine.registerEventListener(simExtension);
+					}
 				});
 
 		engine.registerEventListener(new CoreBehavior(this));

--- a/bundles/org.palladiosimulator.analyzer.slingshot.core/src/org/palladiosimulator/analyzer/slingshot/core/extension/SimulationBehaviorExtension.java
+++ b/bundles/org.palladiosimulator.analyzer.slingshot.core/src/org/palladiosimulator/analyzer/slingshot/core/extension/SimulationBehaviorExtension.java
@@ -2,4 +2,19 @@ package org.palladiosimulator.analyzer.slingshot.core.extension;
 
 public interface SimulationBehaviorExtension {
 
+	/**
+	 * Tells whether this extension should be activated by the
+	 * simulation driver. This is important especially if the extension
+	 * should NOT be activated if the underlying model used to simulate
+	 * is optional itself and hence not provided.
+	 * 
+	 * The default implementation always returns {@code true}.
+	 * 
+	 * @return true iff this extension should be activated and used by the
+	 * 		   driver.
+	 */
+	public default boolean isActive() {
+		return true;
+	}
+	
 }

--- a/features/pom.tycho
+++ b/features/pom.tycho
@@ -1,3 +1,3 @@
-## tycho automatic module detection a8837f25-810a-450c-a253-ff85a12a5c67
+## tycho automatic module detection 3ac5794b-9c66-47bb-b0e7-88083f3d8608
 org.palladiosimulator.analyzer.slingshot.feature
 org.palladiosimulator.analyzer.slingshot.ui.feature


### PR DESCRIPTION
Solves the issue #11 

Now it is possible to mark parameters as nullable, and extensions should only become active if a model is provided.