### PR TITLE
Provide MDSDBlackboard as well

### DIFF
--- a/bundles/org.palladiosimulator.analyzer.slingshot.workflow/src/org/palladiosimulator/analyzer/slingshot/workflow/WorkflowConfigurationModule.java
+++ b/bundles/org.palladiosimulator.analyzer.slingshot.workflow/src/org/palladiosimulator/analyzer/slingshot/workflow/WorkflowConfigurationModule.java
@@ -1,19 +1,23 @@
 package org.palladiosimulator.analyzer.slingshot.workflow;
 
 import org.palladiosimulator.analyzer.slingshot.core.extension.AbstractSlingshotExtension;
+import org.palladiosimulator.analyzer.slingshot.workflow.jobs.MDSDBlackboardProvider;
 
 import de.uka.ipd.sdq.simucomframework.SimuComConfig;
+import de.uka.ipd.sdq.workflow.mdsd.blackboard.MDSDBlackboard;
 
 public class WorkflowConfigurationModule extends AbstractSlingshotExtension {
 
 	static final SimuComConfigProvider simuComConfigProvider = new SimuComConfigProvider();
-
+	public static final MDSDBlackboardProvider blackboardProvider = new MDSDBlackboardProvider();
+	
 	public WorkflowConfigurationModule() {
 	}
 
 	@Override
 	protected void configure() {
 		bind(SimuComConfig.class).toProvider(simuComConfigProvider);
+		bind(MDSDBlackboard.class).toProvider(blackboardProvider);
 	}
 
 	@Override

--- a/bundles/org.palladiosimulator.analyzer.slingshot.workflow/src/org/palladiosimulator/analyzer/slingshot/workflow/jobs/MDSDBlackboardProvider.java
+++ b/bundles/org.palladiosimulator.analyzer.slingshot.workflow/src/org/palladiosimulator/analyzer/slingshot/workflow/jobs/MDSDBlackboardProvider.java
@@ -1,0 +1,20 @@
+package org.palladiosimulator.analyzer.slingshot.workflow.jobs;
+
+import javax.inject.Provider;
+
+import de.uka.ipd.sdq.workflow.mdsd.blackboard.MDSDBlackboard;
+
+public class MDSDBlackboardProvider implements Provider<MDSDBlackboard> {
+
+	private MDSDBlackboard blackboard;
+	
+	void set(final MDSDBlackboard blackboard) {
+		this.blackboard = blackboard;
+	}
+	
+	@Override
+	public MDSDBlackboard get() {
+		return this.blackboard;
+	}
+
+}

--- a/bundles/org.palladiosimulator.analyzer.slingshot.workflow/src/org/palladiosimulator/analyzer/slingshot/workflow/jobs/SimulationJob.java
+++ b/bundles/org.palladiosimulator.analyzer.slingshot.workflow/src/org/palladiosimulator/analyzer/slingshot/workflow/jobs/SimulationJob.java
@@ -6,6 +6,7 @@ import org.eclipse.core.runtime.IProgressMonitor;
 import org.palladiosimulator.analyzer.slingshot.core.Slingshot;
 import org.palladiosimulator.analyzer.slingshot.core.api.SimulationDriver;
 import org.palladiosimulator.analyzer.slingshot.core.extension.PCMResourceSetPartitionProvider;
+import org.palladiosimulator.analyzer.slingshot.workflow.WorkflowConfigurationModule;
 import org.palladiosimulator.analyzer.workflow.ConstantsContainer;
 import org.palladiosimulator.analyzer.workflow.blackboard.PCMResourceSetPartition;
 
@@ -36,6 +37,7 @@ public class SimulationJob implements IBlackboardInteractingJob<MDSDBlackboard> 
 		final PCMResourceSetPartition partition = (PCMResourceSetPartition)
 				this.blackboard.getPartition(ConstantsContainer.DEFAULT_PCM_INSTANCE_PARTITION_ID);
 
+		WorkflowConfigurationModule.blackboardProvider.set(blackboard);
 		this.pcmResourceSetPartition.set(partition);
 		LOGGER.debug("Current partition: ");
 		partition.getResourceSet().getResources().forEach(resource -> LOGGER.debug("Resource: " + resource.getURI().path()));

--- a/releng/org.palladiosimulator.analyzer.slingshot.targetplatform/tp.target
+++ b/releng/org.palladiosimulator.analyzer.slingshot.targetplatform/tp.target
@@ -179,6 +179,32 @@
 		<unit id="org.eclipse.sdk.ide" version="4.22.0.I20211124-1800"/>
 		<unit id="org.eclipse.xsd.ecore.converter.feature.group" version="2.13.0.v20210924-1719"/>
 		<unit id="org.eclipse.xsd.mapping.feature.group" version="2.14.0.v20210924-1719"/>
+		<unit id="org.eclipse.m2m.qvt.oml.debug.feature.group" version="2.10.5.v20211130-1509"/>
+		<unit id="org.eclipse.m2m.qvt.oml.debug.source.feature.group" version="2.10.5.v20211130-1509"/>
+		<unit id="org.eclipse.m2m.qvt.oml.doc.feature.group" version="3.10.5.v20211130-1509"/>
+		<unit id="org.eclipse.m2m.qvt.oml.doc.source.feature.group" version="3.10.5.v20211130-1509"/>
+		<unit id="org.eclipse.m2m.qvt.oml.editor.feature.group" version="3.10.5.v20211130-1509"/>
+		<unit id="org.eclipse.m2m.qvt.oml.editor.jdt.feature.group" version="3.10.5.v20211130-1509"/>
+		<unit id="org.eclipse.m2m.qvt.oml.editor.jdt.source.feature.group" version="3.10.5.v20211130-1509"/>
+		<unit id="org.eclipse.m2m.qvt.oml.editor.source.feature.group" version="3.10.5.v20211130-1509"/>
+		<unit id="org.eclipse.m2m.qvt.oml.examples.feature.group" version="3.10.5.v20211130-1509"/>
+		<unit id="org.eclipse.m2m.qvt.oml.examples.source.feature.group" version="3.10.5.v20211130-1509"/>
+		<unit id="org.eclipse.m2m.qvt.oml.feature.group" version="3.10.5.v20211130-1509"/>
+		<unit id="org.eclipse.m2m.qvt.oml.runtime.feature.group" version="3.10.5.v20211130-1509"/>
+		<unit id="org.eclipse.m2m.qvt.oml.runtime.source.feature.group" version="3.10.5.v20211130-1509"/>
+		<unit id="org.eclipse.m2m.qvt.oml.sdk.feature.group" version="3.10.5.v20211130-1509"/>
+		<unit id="org.eclipse.m2m.qvt.oml.sdk.source.feature.group" version="3.10.5.v20211130-1509"/>
+		<unit id="org.eclipse.m2m.qvt.oml.source.feature.group" version="3.10.5.v20211130-1509"/>
+		<unit id="org.eclipse.m2m.qvt.oml.tools.coverage.feature.group" version="1.6.5.v20211130-1509"/>
+		<unit id="org.eclipse.m2m.qvt.oml.tools.coverage.junit.feature.group" version="1.6.5.v20211130-1509"/>
+		<unit id="org.eclipse.m2m.qvt.oml.tools.coverage.junit.source.feature.group" version="1.6.5.v20211130-1509"/>
+		<unit id="org.eclipse.m2m.qvt.oml.tools.coverage.source.feature.group" version="1.6.5.v20211130-1509"/>
+		<unit id="org.eclipse.qvtd.doc.feature.group" version="0.28.0.v20211130-1516"/>
+		<unit id="org.eclipse.qvtd.doc.source.feature.group" version="0.28.0.v20211130-1516"/>
+		<unit id="org.eclipse.qvtd.examples.feature.group" version="0.28.0.v20211130-1516"/>
+		<unit id="org.eclipse.qvtd.examples.source.feature.group" version="0.28.0.v20211130-1516"/>
+		<unit id="org.eclipse.qvtd.master.feature.group" version="0.28.0.v20211130-1516"/>
+		<unit id="org.eclipse.qvtd.master.source.feature.group" version="0.28.0.v20211130-1516"/>
 	</location>
 	<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 		<repository location="https://download.eclipse.org/tools/orbit/downloads/2021-12/"/>


### PR DESCRIPTION
Before it was not possible to fetch the Blackboard with pcm resource URIs. Now it is possible to Inject MDSDBlackboard as well in the simulation run.

Furthermore, this PR also contains new plugins for QVTo defined in the target file.