### PR TITLE
necessary move for the working of Experiment Automation

### DIFF
--- a/bundles/org.palladiosimulator.analyzer.slingshot.workflow/src/org/palladiosimulator/analyzer/slingshot/workflow/SimulationLauncher.java
+++ b/bundles/org.palladiosimulator.analyzer.slingshot.workflow/src/org/palladiosimulator/analyzer/slingshot/workflow/SimulationLauncher.java
@@ -45,7 +45,6 @@ public class SimulationLauncher extends AbstractPCMLaunchConfigurationDelegate<S
 		}
 		
 		// Currently, this is the only way I found to set the SimuComConfig. Maybe there is a better way?
-		WorkflowConfigurationModule.simuComConfigProvider.set(config);
 		return simulationWorkflowConfiguration;
 	}
 

--- a/bundles/org.palladiosimulator.analyzer.slingshot.workflow/src/org/palladiosimulator/analyzer/slingshot/workflow/jobs/SimulationJob.java
+++ b/bundles/org.palladiosimulator.analyzer.slingshot.workflow/src/org/palladiosimulator/analyzer/slingshot/workflow/jobs/SimulationJob.java
@@ -37,6 +37,7 @@ public class SimulationJob implements IBlackboardInteractingJob<MDSDBlackboard> 
 		final PCMResourceSetPartition partition = (PCMResourceSetPartition)
 				this.blackboard.getPartition(ConstantsContainer.DEFAULT_PCM_INSTANCE_PARTITION_ID);
 
+		WorkflowConfigurationModule.simuComConfigProvider.set(simuComConfig);
 		WorkflowConfigurationModule.blackboardProvider.set(blackboard);
 		this.pcmResourceSetPartition.set(partition);
 		LOGGER.debug("Current partition: ");


### PR DESCRIPTION
Instead of setting the simucomconfig provider in the SimulationLauncher we do that in the SimulationJob, this way the simulation works also for EA. 

