### PR TITLE
Make Assertion Errors visible

### DIFF
--- a/bundles/org.palladiosimulator.analyzer.slingshot.eventdriver/src/org/palladiosimulator/analyzer/slingshot/eventdriver/entity/AnnotatedSubscriber.java
+++ b/bundles/org.palladiosimulator.analyzer.slingshot.eventdriver/src/org/palladiosimulator/analyzer/slingshot/eventdriver/entity/AnnotatedSubscriber.java
@@ -11,15 +11,15 @@ import org.palladiosimulator.analyzer.slingshot.eventdriver.internal.contractche
 import org.palladiosimulator.analyzer.slingshot.eventdriver.returntypes.Result;
 
 public abstract class AnnotatedSubscriber {
-	
+
 	private AnnotatedSubscriber() {
-		
+
 	}
 
-	private static <T> Result<?> acceptEvent(final T event, final Object target, final Method method) throws Exception {
+	private static <T> Result<?> acceptEvent(final T event, final Object target, final Method method) throws Throwable {
 		final Class<?> resultType = method.getReturnType();
 		final Result<?> result;
-		
+
 		try {
 			if (resultType.equals(void.class) || resultType.equals(Void.class)) {
 				// Return type void is equivalent to Result.empty()
@@ -28,21 +28,24 @@ public abstract class AnnotatedSubscriber {
 			} else {
 				result = (Result<?>) method.invoke(target, event);
 			}
-			
+
 			return result;
 		} catch (final InvocationTargetException ex) {
-			if (ex.getCause() != null && ex.getCause() instanceof Exception) {
-				throw (Exception) ex.getCause();
+			if (ex.getCause() != null
+					&& (ex.getCause() instanceof Exception || ex.getCause() instanceof AssertionError)) {
+				ex.getCause().printStackTrace();
+				throw ex.getCause();
 			}
+
 			return Result.empty();
 		}
-		
+
 	}
-	
+
 	public static <T> Subscriber.Builder<T> fromJavaMethod(
-			final Class<T> forEvent, 
-			final Object target, 
-			final Method method, 
+			final Class<T> forEvent,
+			final Object target,
+			final Method method,
 			final Subscribe annotation,
 			final IPreInterceptor preInterceptor,
 			final IPostInterceptor postInterceptor) {

--- a/bundles/org.palladiosimulator.analyzer.slingshot.eventdriver/src/org/palladiosimulator/analyzer/slingshot/eventdriver/entity/EventHandler.java
+++ b/bundles/org.palladiosimulator.analyzer.slingshot.eventdriver/src/org/palladiosimulator/analyzer/slingshot/eventdriver/entity/EventHandler.java
@@ -5,14 +5,14 @@ import org.palladiosimulator.analyzer.slingshot.eventdriver.returntypes.Result;
 /**
  * The actual subscriber of an event of type {@code T} that should be listened
  * to and eventually called.
- * 
+ *
  * @author Julijan Katic
  *
  * @param <T> The event type
  */
 @FunctionalInterface
 public interface EventHandler<T> {
-	
+
 	/**
 	 * A method that will be called upon the event. The method is allowed to through any
 	 * kind of exception, which will be caught by an interceptor and appropriately delegated
@@ -20,12 +20,12 @@ public interface EventHandler<T> {
 	 * <p>
 	 * The method returns a {@link Result} of any kind which the publisher of this event can
 	 * use.
-	 * 
-	 * 
+	 *
+	 *
 	 * @param event The concrete event that was published
 	 * @return A result that holds any kind of information.
 	 * @throws Exception Everything that can be thrown.
 	 */
-	public Result<?> acceptEvent(final T event) throws Exception;
-	
+	public Result<?> acceptEvent(final T event) throws Throwable;
+
 }

--- a/bundles/org.palladiosimulator.analyzer.slingshot.eventdriver/src/org/palladiosimulator/analyzer/slingshot/eventdriver/entity/Subscriber.java
+++ b/bundles/org.palladiosimulator.analyzer.slingshot.eventdriver/src/org/palladiosimulator/analyzer/slingshot/eventdriver/entity/Subscriber.java
@@ -5,6 +5,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
+import org.apache.log4j.Logger;
 import org.palladiosimulator.analyzer.slingshot.eventdriver.entity.interceptors.IPostInterceptor;
 import org.palladiosimulator.analyzer.slingshot.eventdriver.entity.interceptors.IPreInterceptor;
 import org.palladiosimulator.analyzer.slingshot.eventdriver.entity.interceptors.InterceptorInformation;
@@ -13,8 +14,6 @@ import org.palladiosimulator.analyzer.slingshot.eventdriver.returntypes.Result;
 
 import io.reactivex.rxjava3.disposables.Disposable;
 import io.reactivex.rxjava3.functions.Consumer;
-
-import org.apache.log4j.Logger;
 
 /**
  * A subscriber to an event of type {@code T} that should be activated upon the event.
@@ -37,7 +36,7 @@ import org.apache.log4j.Logger;
  * @param <T> The event type
  */
 public class Subscriber<T> implements Consumer<T>, Disposable, Comparable<Subscriber<T>>, InterceptorInformation {
-		
+
 	private static final Logger LOGGER = Logger.getLogger(Subscriber.class);
 
 	private boolean disposed = false;
@@ -67,7 +66,7 @@ public class Subscriber<T> implements Consumer<T>, Disposable, Comparable<Subscr
 	}
 
 	@Override
-	public void accept(final T event) throws Exception {
+	public void accept(final T event) throws Throwable {
 		final InterceptorInformation preInterceptionInformation = this;
 
 		final InterceptionResult preInterceptionResult = this.preInterceptor
@@ -85,7 +84,7 @@ public class Subscriber<T> implements Consumer<T>, Disposable, Comparable<Subscr
 		final InterceptionResult postInterceptionResult = this.postInterceptor
 				.map(postInterceptor -> postInterceptor.apply(preInterceptionInformation, event, result))
 				.orElseGet(InterceptionResult::success);
-		
+
 		LOGGER.info("Post interception result was successful: " + postInterceptionResult.wasSuccessful());
 	}
 


### PR DESCRIPTION
# Current

AssertionErrors are silently swallowed somewhere inside the Subscriber implementation, we wont even get a log message about them. 

# New

Assertion error are logged in the runtime Eclipse Instance. 
Also StackTrace for all Exceptions are printed to the parent Eclipse Instance, such that they are clickable. The logs in the runtime Eclipse insance are not clickable, which makes it painfull for debugging. 

# Misc 
The switch from `Exception` to `Throwable` was necessary, as `Throwable` is the smallest common supertype of `AssertionError` and `Exception`.