### PR TITLE
Workflow changes for E2E Testing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,22 @@
+name: Trigger E2E Test Build
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  notify-e2e-repo:
+    if: github.event.issue.pull_request != '' && contains(github.event.comment.body, '/ready_to_test')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up branch name
+        id: set_branch
+        run: echo "BRANCH_NAME=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
+
+      - name: Repository Dispatch to E2E Repo
+        uses: peter-evans/repository-dispatch@v1
+        with:
+          token: ${{ secrets.E2E_PTA }}
+          repository: 'PalladioSimulator/Palladio-Analyzer-Slingshot-E2E-Tests'
+          event-type: 'build-trigger'
+          client-payload: '{"slingshot_branch": "${{ env.BRANCH_NAME }}"}'


### PR DESCRIPTION
This build.yml will trigger the E2E testing repository as discussed. With a "/ready-to-test" command this workflow will be activated

Things to do for Slingshot team:
1) Activate actions in this repository
2) Add a repo wide token to the secrets and name it E2E_PTA 
3) Merge the branch with master