### PR TITLE
remove duplicate id.

### DIFF
--- a/bundles/org.palladiosimulator.analyzer.slingshot.common/src/org/palladiosimulator/analyzer/slingshot/common/events/AbstractEntityChangedEvent.java
+++ b/bundles/org.palladiosimulator.analyzer.slingshot.common/src/org/palladiosimulator/analyzer/slingshot/common/events/AbstractEntityChangedEvent.java
@@ -5,17 +5,10 @@ import java.util.Objects;
 public abstract class AbstractEntityChangedEvent<T> extends AbstractSimulationEvent {
 
 	private final T entity;
-	private final String id;
-	
+
 	public AbstractEntityChangedEvent(final T entity, final double delay) {
-		super("", delay);
+		super(delay);
 		this.entity = Objects.requireNonNull(entity);
-		this.id = String.format("%s-%X", getClass().getSimpleName(), entity.hashCode());
-	}
-	
-	@Override
-	public String getId() {
-		return id;
 	}
 	
 	public T getEntity() {


### PR DESCRIPTION
## Current Behaviour

Class `AbstractEvent` has a field `id`, the child class `AbstractEntityChangedEvent` also has a field `id` which it uses instead of the `id`-field from the ancestor class.
This is inconsistent and creates problems when attempting to serialize the events, because we end up with a duplicate field.

## New Behaviour

No dedicated `id`-field for `AbstractEntityChangedEvent`, instead use the id as implemented in the ancestor class. 