### PR TITLE
Make FEL accessible

### DIFF
--- a/bundles/org.palladiosimulator.analyzer.slingshot.core/src/org/palladiosimulator/analyzer/slingshot/core/api/SimulationEngine.java
+++ b/bundles/org.palladiosimulator.analyzer.slingshot.core/src/org/palladiosimulator/analyzer/slingshot/core/api/SimulationEngine.java
@@ -1,5 +1,7 @@
 package org.palladiosimulator.analyzer.slingshot.core.api;
 
+import java.util.Set;
+
 import org.palladiosimulator.analyzer.slingshot.common.events.DESEvent;
 import org.palladiosimulator.analyzer.slingshot.core.extension.SimulationBehaviorExtension;
 import org.palladiosimulator.analyzer.slingshot.eventdriver.entity.Subscriber;
@@ -23,5 +25,7 @@ public interface SimulationEngine {
 	public void registerEventListener(final SimulationBehaviorExtension guavaEventClass);
 
 	public <T> void registerEventListener(final Subscriber<T> subscriber);
+
+	public Set<DESEvent> getScheduledEvents();
 
 }

--- a/bundles/org.palladiosimulator.analyzer.slingshot.core/src/org/palladiosimulator/analyzer/slingshot/core/engine/SimulationEngineSSJ.java
+++ b/bundles/org.palladiosimulator.analyzer.slingshot.core/src/org/palladiosimulator/analyzer/slingshot/core/engine/SimulationEngineSSJ.java
@@ -1,5 +1,9 @@
 package org.palladiosimulator.analyzer.slingshot.core.engine;
 
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Set;
+
 import javax.inject.Singleton;
 
 import org.apache.log4j.LogManager;
@@ -114,6 +118,10 @@ public class SimulationEngineSSJ implements SimulationEngine, SimulationInformat
 			cumulativeEvents++;
 		}
 
+		private DESEvent getDESEvent() {
+			return this.event;
+		}
+
 	}
 
 	@Override
@@ -125,6 +133,20 @@ public class SimulationEngineSSJ implements SimulationEngine, SimulationInformat
 	@Override
 	public <T> void registerEventListener(final Subscriber<T> subscriber) {
 		this.eventBus.register(subscriber);
+	}
+
+	@Override
+	public Set<DESEvent> getScheduledEvents() {
+		final Iterator<Event> events = simulator.getEventList().iterator();
+		final Set<DESEvent> desevents = new HashSet<>();
+
+		while (events.hasNext()) {
+			final SSJEvent ssjEvent = (SSJEvent) events.next();
+			final DESEvent desevent = ssjEvent.getDESEvent();
+			desevent.setTime(ssjEvent.time());
+			desevents.add(desevent);
+		}
+		return desevents;
 	}
 
 }


### PR DESCRIPTION
## Current Behaviour
Futureeventlist (FEL) inside the simulation engine is not accessible to the outside. 

## New Behaviour 
SimulationEngine provides a getter to pass all events in the FEL to the caller.

## Reasoning
1. The MENTOR stateexploration requires access to the FEL to create snapshots of a simulation run. 
2. The simulator, on which slingshot engine relies also offers access to the FEL.