### PR TITLE
PR82  refactor request context for operation call response time measurement. #82 

### DIFF
--- a/bundles/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.monitor/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/monitor/AssemblyOperationCompoundKey.java
+++ b/bundles/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.monitor/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/monitor/AssemblyOperationCompoundKey.java
@@ -50,7 +50,7 @@ public final class AssemblyOperationCompoundKey {
 
 	@Override
 	public String toString() {
-		return this.assemblyContext.getId() + ":" + this.providedRole.getId();
+		return this.assemblyContext.getId() + ":" + this.providedRole.getId() + ":" + this.signature.getId();
 	}
 
 	public static AssemblyOperationCompoundKey of(final SEFFInterpretationContext context) {

--- a/bundles/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.monitor/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/monitor/OperationCallActionResponseTimeMonitoringBehavior.java
+++ b/bundles/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.monitor/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/monitor/OperationCallActionResponseTimeMonitoringBehavior.java
@@ -25,6 +25,7 @@ import org.palladiosimulator.metricspec.constants.MetricDescriptionConstants;
 import org.palladiosimulator.monitorrepository.MeasurementSpecification;
 import org.palladiosimulator.pcm.repository.OperationProvidedRole;
 import org.palladiosimulator.pcm.repository.ProvidedRole;
+import org.palladiosimulator.pcm.seff.AbstractAction;
 import org.palladiosimulator.pcm.seff.StartAction;
 import org.palladiosimulator.pcm.seff.StopAction;
 import org.palladiosimulator.pcmmeasuringpoint.AssemblyOperationMeasuringPoint;
@@ -161,7 +162,9 @@ public class OperationCallActionResponseTimeMonitoringBehavior implements Simula
 				final SEFFModelPassedElement<?> el = (SEFFModelPassedElement<?>) desEvent;
 
 				if(el.getContext().getCaller().isPresent()) {
-					return new RequestContext(el.getContext().getRequestProcessingContext().getUser().getId()+el.getContext().getCaller().get().hashCode());
+					return new RequestContext(el.getContext().getRequestProcessingContext().getUser().getId() + ":"
+							+ ((AbstractAction) el.getModelElement())
+							.getResourceDemandingBehaviour_AbstractAction().getId());
 				} else {
 					return new RequestContext(el.getContext().getRequestProcessingContext().getUser().getId());
 				}

--- a/bundles/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.monitor/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/monitor/OperationCallActionResponseTimeMonitoringBehavior.java
+++ b/bundles/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.monitor/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/monitor/OperationCallActionResponseTimeMonitoringBehavior.java
@@ -163,6 +163,7 @@ public class OperationCallActionResponseTimeMonitoringBehavior implements Simula
 
 				if(el.getContext().getCaller().isPresent()) {
 					return new RequestContext(el.getContext().getRequestProcessingContext().getUser().getId() + ":"
+							+ el.getContext().getAssemblyContext().getId() + ":"
 							+ ((AbstractAction) el.getModelElement())
 							.getResourceDemandingBehaviour_AbstractAction().getId());
 				} else {


### PR DESCRIPTION
- **refactor request context for operation call response time measurements to use the RDSEFF behaviour id instead of the SEFFIC hash.**
- **improve to-string, enhance request context.**
