### PR TITLE
Add headless CLI product for simulation

### DIFF
--- a/bundles/org.palladiosimulator.analyzer.slingshot.headless/META-INF/MANIFEST.MF
+++ b/bundles/org.palladiosimulator.analyzer.slingshot.headless/META-INF/MANIFEST.MF
@@ -1,0 +1,20 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: Headless CLI
+Bundle-SymbolicName: org.palladiosimulator.analyzer.slingshot.headless;singleton:=true
+Bundle-Version: 1.0.0.qualifier
+Automatic-Module-Name: org.palladiosimulator.analyzer.slingshot.headless
+Bundle-RequiredExecutionEnvironment: JavaSE-17
+Require-Bundle: org.eclipse.core.runtime,
+ org.eclipse.equinox.app,
+ org.palladiosimulator.analyzer.slingshot.core,
+ org.palladiosimulator.analyzer.slingshot.workflow,
+ org.palladiosimulator.analyzer.slingshot.workflow.events,
+ org.palladiosimulator.analyzer.workflow.core,
+ de.uka.ipd.sdq.workflow.mdsd.blackboard,
+ de.uka.ipd.sdq.simucomframework,
+ org.palladiosimulator.pcm,
+ org.eclipse.emf.ecore,
+ org.eclipse.emf.common
+Bundle-ActivationPolicy: lazy
+Export-Package: org.palladiosimulator.analyzer.slingshot.headless

--- a/bundles/org.palladiosimulator.analyzer.slingshot.headless/build.properties
+++ b/bundles/org.palladiosimulator.analyzer.slingshot.headless/build.properties
@@ -1,0 +1,5 @@
+source.. = src/
+output.. = bin/
+bin.includes = META-INF/,\
+               .,\
+               plugin.xml

--- a/bundles/org.palladiosimulator.analyzer.slingshot.headless/plugin.xml
+++ b/bundles/org.palladiosimulator.analyzer.slingshot.headless/plugin.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?eclipse version="3.4"?>
+<plugin>
+   <extension
+         id="slingshotHeadless"
+         point="org.eclipse.core.runtime.applications">
+      <application>
+         <run
+               class="org.palladiosimulator.analyzer.slingshot.headless.HeadlessApplication">
+         </run>
+      </application>
+   </extension>
+</plugin>

--- a/bundles/org.palladiosimulator.analyzer.slingshot.headless/src/org/palladiosimulator/analyzer/slingshot/headless/HeadlessApplication.java
+++ b/bundles/org.palladiosimulator.analyzer.slingshot.headless/src/org/palladiosimulator/analyzer/slingshot/headless/HeadlessApplication.java
@@ -1,0 +1,156 @@
+package org.palladiosimulator.analyzer.slingshot.headless;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.equinox.app.IApplication;
+import org.eclipse.equinox.app.IApplicationContext;
+import org.palladiosimulator.analyzer.slingshot.core.Slingshot;
+import org.palladiosimulator.analyzer.slingshot.core.api.SimulationDriver;
+import org.palladiosimulator.analyzer.slingshot.core.extension.PCMResourceSetPartitionProvider;
+import org.palladiosimulator.analyzer.slingshot.workflow.WorkflowConfigurationModule;
+import org.palladiosimulator.analyzer.workflow.core.ConstantsContainer;
+import org.palladiosimulator.analyzer.workflow.core.blackboard.PCMResourceSetPartition;
+import org.palladiosimulator.analyzer.workflow.core.jobs.LoadModelIntoBlackboardJob;
+import org.palladiosimulator.analyzer.workflow.core.jobs.PreparePCMBlackboardPartitionJob;
+
+import de.uka.ipd.sdq.simucomframework.core.SimuComConfig;
+import de.uka.ipd.sdq.workflow.mdsd.blackboard.MDSDBlackboard;
+
+public class HeadlessApplication implements IApplication {
+
+	private static final String ARG_ALLOCATION = "--allocation";
+	private static final String ARG_SYSTEM = "--system";
+	private static final String ARG_REPOSITORY = "--repository";
+	private static final String ARG_RESOURCE_ENV = "--resourceenvironment";
+	private static final String ARG_USAGE_MODEL = "--usagemodel";
+	private static final String ARG_SIMULATION_TIME = "--simulationTime";
+	private static final String ARG_MAX_MEASUREMENTS = "--maxMeasurements";
+	private static final String ARG_SEED = "--seed";
+	private static final String ARG_HELP = "--help";
+
+	private SimulationDriver driver;
+
+	@Override
+	public Object start(final IApplicationContext context) throws Exception {
+		final Map<?, ?> args = context.getArguments();
+		final String[] appArgs = (String[]) args.get("application.args");
+
+		final Map<String, String> parsed = parseArgs(appArgs != null ? appArgs : new String[0]);
+
+		if (parsed.containsKey(ARG_HELP) || parsed.isEmpty()) {
+			printHelp();
+			return IApplication.EXIT_OK;
+		}
+
+		final List<String> modelFiles = new ArrayList<>();
+		addIfPresent(parsed, ARG_ALLOCATION, modelFiles);
+		addIfPresent(parsed, ARG_SYSTEM, modelFiles);
+		addIfPresent(parsed, ARG_REPOSITORY, modelFiles);
+		addIfPresent(parsed, ARG_RESOURCE_ENV, modelFiles);
+		addIfPresent(parsed, ARG_USAGE_MODEL, modelFiles);
+
+		if (modelFiles.isEmpty()) {
+			System.err.println("Error: No model files provided.");
+			printHelp();
+			return Integer.valueOf(1);
+		}
+
+		final IProgressMonitor monitor = new NullProgressMonitor();
+
+		final MDSDBlackboard blackboard = new MDSDBlackboard();
+		final String partitionId = ConstantsContainer.DEFAULT_PCM_INSTANCE_PARTITION_ID;
+
+		final PreparePCMBlackboardPartitionJob partitionJob = new PreparePCMBlackboardPartitionJob();
+		partitionJob.setBlackboard(blackboard);
+		partitionJob.execute(monitor);
+
+		for (final String modelFile : modelFiles) {
+			final LoadModelIntoBlackboardJob loadJob = new LoadModelIntoBlackboardJob(
+					org.eclipse.emf.common.util.URI.createFileURI(modelFile), partitionId);
+			loadJob.setBlackboard(blackboard);
+			loadJob.execute(monitor);
+		}
+
+		final Map<String, Object> configMap = new HashMap<>();
+		configMap.put(SimuComConfig.SIMULATION_TIME, parsed.getOrDefault(ARG_SIMULATION_TIME, "1000"));
+		configMap.put(SimuComConfig.MAXIMUM_MEASUREMENT_COUNT,
+				parsed.getOrDefault(ARG_MAX_MEASUREMENTS, "100000"));
+		if (parsed.containsKey(ARG_SEED)) {
+			configMap.put(SimuComConfig.USE_FIXED_SEED, true);
+			configMap.put(SimuComConfig.SIMULATOR_ID, parsed.get(ARG_SEED));
+		}
+		final SimuComConfig config = new SimuComConfig(configMap, true);
+
+		WorkflowConfigurationModule.simuComConfigProvider.set(config);
+		WorkflowConfigurationModule.blackboardProvider.set(blackboard);
+
+		final PCMResourceSetPartition partition = (PCMResourceSetPartition) blackboard
+				.getPartition(partitionId);
+		Slingshot.getInstance().getInstance(PCMResourceSetPartitionProvider.class).set(partition);
+
+		this.driver = Slingshot.getInstance().getSimulationDriver();
+		this.driver.init(config, monitor);
+		this.driver.start();
+
+		return IApplication.EXIT_OK;
+	}
+
+	@Override
+	public void stop() {
+		if (this.driver != null && this.driver.isRunning()) {
+			this.driver.stop();
+		}
+	}
+
+	private static Map<String, String> parseArgs(final String[] args) {
+		final Map<String, String> result = new LinkedHashMap<>();
+		for (int i = 0; i < args.length; i++) {
+			if (args[i].startsWith("--")) {
+				if (i + 1 < args.length && !args[i + 1].startsWith("--")) {
+					result.put(args[i], args[i + 1]);
+					i++;
+				} else {
+					result.put(args[i], "");
+				}
+			}
+		}
+		return result;
+	}
+
+	private static void addIfPresent(final Map<String, String> parsed, final String key,
+			final List<String> target) {
+		final String value = parsed.get(key);
+		if (value != null && !value.isEmpty()) {
+			target.add(value);
+		}
+	}
+
+	private static void printHelp() {
+		System.out.println("Slingshot Headless Simulation");
+		System.out.println();
+		System.out.println("Usage: slingshot-headless [options]");
+		System.out.println();
+		System.out.println("Required (at least one model file):");
+		System.out.println("  --allocation <uri>             PCM allocation model");
+		System.out.println("  --system <uri>                 PCM system model");
+		System.out.println("  --repository <uri>             PCM repository model");
+		System.out.println("  --resourceenvironment <uri>    PCM resource environment model");
+		System.out.println("  --usagemodel <uri>             PCM usage model");
+		System.out.println();
+		System.out.println("Optional:");
+		System.out.println("  --simulationTime <double>    Simulation end time (default: 1000)");
+		System.out.println("  --maxMeasurements <int>      Max measurement count (default: 100000)");
+		System.out.println("  --seed <long>                Fixed random seed");
+		System.out.println("  --help                       Print this help");
+		System.out.println();
+		System.out.println("Example:");
+		System.out.println(
+				"  slingshot-headless --allocation model.allocation --repository model.repository --simulationTime 5000 --seed 42");
+	}
+}

--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -44,5 +44,8 @@
 		<module>org.palladiosimulator.analyzer.slingshot.behavior.spd</module>
 		<module>org.palladiosimulator.analyzer.slingshot.behavior.spd.adjustment</module>
 		<module>org.palladiosimulator.analyzer.slingshot.behavior.spd.data</module>
+
+    <!-- Headless CLI -->
+    <module>org.palladiosimulator.analyzer.slingshot.headless</module>
   </modules>
 </project>

--- a/docs/adr/001-headless-cli-product.md
+++ b/docs/adr/001-headless-cli-product.md
@@ -1,0 +1,61 @@
+# ADR 001: Headless CLI Product for Slingshot Simulation
+
+**Date:** 2026-06-12
+**Status:** Accepted
+**Deciders:** Floriment Klinaku
+
+## Context
+
+The Palladio-Analyzer-Slingshot project provides a discrete-event simulation engine for the Palladio Architecture Simulator. Historically, simulations could only be launched through the Eclipse/Palladio Bench IDE via a "Slingshot Simulation" run configuration (UI-based). This tight coupling to the Eclipse UI framework prevented:
+
+- Integration into CI/CD pipelines and automated regression testing
+- Scripted batch simulation runs (e.g., parameter sweeps, sensitivity analysis)
+- Usage in non-GUI environments (servers, containers, headless HPC clusters)
+
+The core simulation engine (`org.palladiosimulator.analyzer.slingshot.core`) and its extension system are already decoupled from the UI — they use Google Guice dependency injection and an event-driven architecture. Only the launch plumbing (`SimulationLauncher`, `SimulationWorkflowConfiguration`) depends on Eclipse UI classes like `AbstractPCMLaunchConfigurationDelegate`.
+
+## Decision
+
+We will implement a **headless Eclipse RCP product** that provides a CLI entry point for running Slingshot simulations without the Palladio Bench IDE.
+
+### Approach
+
+1. **New bundle** `org.palladiosimulator.analyzer.slingshot.headless` containing:
+   - `HeadlessApplication` implementing `org.eclipse.equinox.app.IApplication`
+   - CLI argument parsing for PCM model paths and simulation parameters
+   - Direct invocation of `SimulationDriver.init()` and `SimulationDriver.start()` (bypassing Eclipse launch framework)
+
+2. **New product definition** `slingshot-headless.product` configured as an Eclipse `.product` file with `eclipse-repository` packaging via Tycho. The product:
+   - Includes the core feature (no UI feature)
+   - Includes all extension features (PCM core, monitoring, SPD)
+   - Sets `eclipse.application` to the headless application ID
+   - Does not include native launchers (runs via `java -jar plugins/org.eclipse.equinox.launcher_*.jar`)
+
+3. **Reuses existing infrastructure**:
+   - `PreparePCMBlackboardPartitionJob` and `LoadModelIntoBlackboardJob` for model loading
+   - `WorkflowConfigurationModule` static providers for wiring config into Guice
+   - `SimuComConfig` with `Map<String, Object>` constructor for configuration
+
+### Non-Goals
+
+- This is NOT a standalone Java executable — it remains an Eclipse RCP application that requires an OSGi runtime
+- No changes to the core simulation engine or existing extension mechanism
+- No native launchers (no `.exe`/`eclipse` binary) — users invoke via `java -jar`
+
+## Consequences
+
+### Positive
+- Simulations can be run from CLI, enabling scripting and automation
+- Same simulation engine, same extensions — guaranteed behavioral compatibility
+- The headless product can be built alongside the existing update site with no build system changes
+- Minimal new code (~120 lines of Java)
+
+### Negative
+- Still requires JDK 17+ and the Eclipse Equinox OSGi runtime (~200MB distribution)
+- Users must provide the `org.palladiosimulator.pcm.resources` bundle for PrimitiveTypes pathmap resolution (included automatically via feature dependencies)
+- Full simulation integration tests require the complete E2E test environment (all extension bundles)
+
+### Neutral
+- The product is built and tested as part of the regular Maven/Tycho build
+- Platform-specific archives are generated for macOS (aarch64, x86_64), Linux (aarch64, x86_64), and Windows (x86_64)
+- Users run with `-application` flag pointing to the headless application ID

--- a/docs/requirements/headless-cli.md
+++ b/docs/requirements/headless-cli.md
@@ -1,0 +1,105 @@
+# Slingshot Headless CLI — Requirements
+
+## Overview
+
+The Slingshot Headless CLI allows running Palladio Architecture Simulator simulations from the command line, without the Eclipse/Palladio Bench IDE.
+
+## Build
+
+```bash
+JAVA_HOME=/path/to/jdk17 mvn clean verify
+```
+
+The product archives are generated at:
+```
+releng/org.palladiosimulator.analyzer.slingshot.headless.product/target/products/
+├── slingshot-headless.product-macosx.cocoa.aarch64.zip
+├── slingshot-headless.product-macosx.cocoa.x86_64.zip
+├── slingshot-headless.product-linux.gtk.aarch64.zip
+├── slingshot-headless.product-linux.gtk.x86_64.zip
+└── slingshot-headless.product-win32.win32.x86_64.zip
+```
+
+## Usage
+
+```bash
+# Extract the product for your platform
+unzip slingshot-headless.product-macosx.cocoa.aarch64.zip
+cd Eclipse.app/Contents/Eclipse
+
+# Run a simulation
+java -jar plugins/org.eclipse.equinox.launcher_*.jar \
+  -application org.palladiosimulator.analyzer.slingshot.headless.slingshotHeadless \
+  -data /tmp/workspace \
+  --allocation /path/to/model.allocation \
+  --repository /path/to/model.repository \
+  --system /path/to/model.system \
+  --resourceenvironment /path/to/model.resourceenvironment \
+  --usagemodel /path/to/model.usagemodel \
+  --simulationTime 5000 \
+  --seed 42
+```
+
+## Arguments
+
+| Argument | Type | Required | Default | Description |
+|----------|------|----------|---------|-------------|
+| `--allocation <uri>` | file path | No* | — | PCM allocation model |
+| `--system <uri>` | file path | No* | — | PCM system model |
+| `--repository <uri>` | file path | No* | — | PCM repository model |
+| `--resourceenvironment <uri>` | file path | No* | — | PCM resource environment model |
+| `--usagemodel <uri>` | file path | No* | — | PCM usage model |
+| `--simulationTime <double>` | number | No | `1000` | Simulation end time |
+| `--maxMeasurements <int>` | number | No | `100000` | Max measurement count before stopping |
+| `--seed <long>` | number | No | (random) | Fixed random seed for reproducibility |
+| `--help` | flag | No | — | Print usage and exit |
+
+\* At least one model file argument is required.
+
+## Architecture
+
+```
+User (CLI)
+  │
+  ▼
+HeadlessApplication (IApplication)
+  ├── Parse CLI args ──────────────────► Map<String, String>
+  ├── Create MDSDBlackboard
+  ├── PreparePCMBlackboardPartitionJob ──► Initialize PCM partition
+  ├── LoadModelIntoBlackboardJob (×N) ──► Load each model file
+  ├── Build SimuComConfig from args
+  ├── Configure providers (blackboard, partition, config)
+  └── SimulationDriver.init() + start()
+
+SimulationDriver
+  ├── Create Guice child injector
+  ├── Register extensions (behavior, monitoring, SPD, etc.)
+  └── SSJ simulation event loop
+```
+
+## Dependencies (Runtime)
+
+The product includes (via features):
+- Slingshot core, common, eventdriver, workflow
+- PCM core behavior extensions (resource, system, usage simulation)
+- Monitoring extensions
+- SPD interpreter extensions
+- All transitive Eclipse/EMF/Guice/Palladio dependencies
+
+Not included (excluded from core feature):
+- Eclipse UI/workbench bundles
+- Palladio Bench IDE UI
+- Debug UI, editors, etc.
+
+## Testing
+
+Unit and integration tests are in `tests/org.palladiosimulator.analyzer.slingshot.headless.test/`:
+
+| Test | What it verifies |
+|------|------------------|
+| `modelDirectoriesExist` | Test model files are present |
+| `slingshotInstanceIsAvailable` | OSGi-initialized Slingshot singleton |
+| `minimalModelLoadsIntoBlackboard` | MinimalModel PCM files load into blackboard |
+| `usageModelLoadsIntoBlackboard` | UsageModelOnly PCM files load into blackboard |
+
+Full simulation integration tests (requiring all extension bundles) are in the separate `Palladio-Analyzer-Slingshot-E2E-Tests` repository.

--- a/examples/headless-simulation/README.md
+++ b/examples/headless-simulation/README.md
@@ -1,0 +1,53 @@
+# Slingshot Headless — Example: MinimalModel
+
+This directory contains a minimal PCM model set (`MinimalModel`) that you can use to test the Slingshot Headless CLI.
+
+## Model Contents
+
+| File | Type |
+|------|------|
+| `models/MinimalModel/minimal.allocation` | Allocation |
+| `models/MinimalModel/minimal.repository` | Repository |
+| `models/MinimalModel/minimal.system` | System |
+| `models/MinimalModel/minimal.resourceenvironment` | Resource Environment |
+| `models/MinimalModel/minimal.usagemodel` | Usage Model |
+| `models/MinimalModel/minimal.monitorrepository` | Monitor Repository |
+| `models/MinimalModel/minimal.measuringpoint` | Measuring Point |
+| `models/MinimalModel/minimal.spd` | Scaling Policy Definition |
+
+## Prerequisites
+
+- JDK 17+
+- The Slingshot headless product ZIP for your platform (build from the project root):
+  ```bash
+  JAVA_HOME=/path/to/jdk17 mvn clean verify
+  # Product ZIPs are in:
+  # releng/.../headless.product/target/products/
+  ```
+
+## Running
+
+```bash
+# 1. Extract the product
+unzip path/to/slingshot-headless.product-macosx.cocoa.aarch64.zip
+cd Eclipse.app/Contents/Eclipse
+
+# 2. Run with the example model
+java -jar plugins/org.eclipse.equinox.launcher_*.jar \
+  -application org.palladiosimulator.analyzer.slingshot.headless.slingshotHeadless \
+  -data /tmp/slingshot-workspace \
+  --allocation path/to/examples/headless-simulation/models/MinimalModel/minimal.allocation \
+  --repository path/to/examples/headless-simulation/models/MinimalModel/minimal.repository \
+  --system path/to/examples/headless-simulation/models/MinimalModel/minimal.system \
+  --resourceenvironment path/to/examples/headless-simulation/models/MinimalModel/minimal.resourceenvironment \
+  --usagemodel path/to/examples/headless-simulation/models/MinimalModel/minimal.usagemodel \
+  --simulationTime 10 \
+  --seed 12345
+```
+
+Or use the convenience script:
+
+```bash
+# From the project root
+./examples/headless-simulation/run.sh
+```

--- a/examples/headless-simulation/models/minimal.allocation
+++ b/examples/headless-simulation/models/minimal.allocation
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="ASCII"?>
+<allocation:Allocation xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:allocation="http://palladiosimulator.org/PalladioComponentModel/Allocation/5.2" id="_GgAmgBDVEe6FXrMRahCZ6g" entityName="New Allocation">
+  <targetResourceEnvironment_Allocation href="minimal.resourceenvironment#/"/>
+  <system_Allocation href="minimal.system#_CVBz0BDVEe6FXrMRahCZ6g"/>
+  <allocationContexts_Allocation id="_FsIKIBDjEe6FXrMRahCZ6g" entityName="Allocation_Assembly_BasicComponent1">
+    <resourceContainer_AllocationContext href="minimal.resourceenvironment#_9pUxUBDiEe6FXrMRahCZ6g"/>
+    <assemblyContext_AllocationContext href="minimal.system#_07_00BDiEe6FXrMRahCZ6g"/>
+  </allocationContexts_Allocation>
+</allocation:Allocation>

--- a/examples/headless-simulation/models/minimal.measuringpoint
+++ b/examples/headless-simulation/models/minimal.measuringpoint
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<org.palladiosimulator.edp2.models:MeasuringPointRepository xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:org.palladiosimulator.edp2.models="http://palladiosimulator.org/EDP2/MeasuringPoint/1.0" xmlns:pcmmeasuringpoint="http://palladiosimulator.org/PCM/MeasuringPoint/1.0" id="_DgOGgBDTEe6FXrMRahCZ6g">
+  <measuringPoints xsi:type="pcmmeasuringpoint:UsageScenarioMeasuringPoint" stringRepresentation="Usage Scenario: ClosedWorkloadUsageScenario" resourceURIRepresentation="platform:/resource/testCaseEditing/minimalModelSet.usageModelOnly/minimal.usagemodel#_LPnI8CHdEd6lJo4DCALHMw">
+    <usageScenario href="minimal.usagemodel#_LPnI8CHdEd6lJo4DCALHMw"/>
+  </measuringPoints>
+</org.palladiosimulator.edp2.models:MeasuringPointRepository>

--- a/examples/headless-simulation/models/minimal.monitorrepository
+++ b/examples/headless-simulation/models/minimal.monitorrepository
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<monitorrepository:MonitorRepository xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:metricspec="http://palladiosimulator.org/MetricSpec/1.0" xmlns:monitorrepository="http://palladiosimulator.org/MonitorRepository/1.0" xmlns:pcmmeasuringpoint="http://palladiosimulator.org/PCM/MeasuringPoint/1.0" id="_Av7JIBDTEe6FXrMRahCZ6g">
+  <monitors id="_HVyC0BDTEe6FXrMRahCZ6g">
+    <measurementSpecifications id="_JmmO4BDTEe6FXrMRahCZ6g">
+      <metricDescription xsi:type="metricspec:NumericalBaseMetricDescription" href="pathmap://METRIC_SPEC_MODELS/commonMetrics.metricspec#_6rYmYs7nEeOX_4BzImuHbA"/>
+      <processingType xsi:type="monitorrepository:FeedThrough" id="_N5hcoBDTEe6FXrMRahCZ6g"/>
+    </measurementSpecifications>
+    <measuringPoint xsi:type="pcmmeasuringpoint:UsageScenarioMeasuringPoint" href="minimal.measuringpoint#//@measuringPoints.0"/>
+  </monitors>
+</monitorrepository:MonitorRepository>

--- a/examples/headless-simulation/models/minimal.repository
+++ b/examples/headless-simulation/models/minimal.repository
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="ASCII"?>
+<repository:Repository xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:repository="http://palladiosimulator.org/PalladioComponentModel/Repository/5.2" xmlns:seff="http://palladiosimulator.org/PalladioComponentModel/SEFF/5.2" id="_bhko4BDiEe6FXrMRahCZ6g" entityName="New Repository">
+  <components__Repository xsi:type="repository:BasicComponent" id="_i05skBDiEe6FXrMRahCZ6g" entityName="BasicComponent1">
+    <providedRoles_InterfaceProvidingEntity xsi:type="repository:OperationProvidedRole" id="_nLjjwBDiEe6FXrMRahCZ6g" entityName="BasicComponent1.Interface1.OperationProvidedRole1" providedInterface__OperationProvidedRole="_h6nOkBDiEe6FXrMRahCZ6g"/>
+    <serviceEffectSpecifications__BasicComponent xsi:type="seff:ResourceDemandingSEFF" id="_nL4T4BDiEe6FXrMRahCZ6g" describedService__SEFF="_k2ph4BDiEe6FXrMRahCZ6g">
+      <steps_Behaviour xsi:type="seff:StartAction" id="_nL6JEBDiEe6FXrMRahCZ6g" successor_AbstractAction="_obMmsBDiEe6FXrMRahCZ6g"/>
+      <steps_Behaviour xsi:type="seff:StopAction" id="_nL6wIBDiEe6FXrMRahCZ6g" predecessor_AbstractAction="_obMmsBDiEe6FXrMRahCZ6g"/>
+      <steps_Behaviour xsi:type="seff:InternalAction" id="_obMmsBDiEe6FXrMRahCZ6g" entityName="InternalAction1" predecessor_AbstractAction="_nL6JEBDiEe6FXrMRahCZ6g" successor_AbstractAction="_nL6wIBDiEe6FXrMRahCZ6g">
+        <resourceDemand_Action>
+          <specification_ParametericResourceDemand specification="1.0"/>
+          <requiredResource_ParametricResourceDemand href="pathmap://PCM_MODELS/Palladio.resourcetype#_oro4gG3fEdy4YaaT-RYrLQ"/>
+        </resourceDemand_Action>
+      </steps_Behaviour>
+    </serviceEffectSpecifications__BasicComponent>
+  </components__Repository>
+  <interfaces__Repository xsi:type="repository:OperationInterface" id="_h6nOkBDiEe6FXrMRahCZ6g" entityName="Interface1">
+    <signatures__OperationInterface id="_k2ph4BDiEe6FXrMRahCZ6g" entityName="method1"/>
+  </interfaces__Repository>
+</repository:Repository>

--- a/examples/headless-simulation/models/minimal.resourceenvironment
+++ b/examples/headless-simulation/models/minimal.resourceenvironment
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="ASCII"?>
+<resourceenvironment:ResourceEnvironment xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:resourceenvironment="http://palladiosimulator.org/PalladioComponentModel/ResourceEnvironment/5.2" entityName="New ResourceEnvironment">
+  <resourceContainer_ResourceEnvironment id="_9pUxUBDiEe6FXrMRahCZ6g" entityName="ResourceContainer1">
+    <activeResourceSpecifications_ResourceContainer id="_-dbu0BDiEe6FXrMRahCZ6g">
+      <schedulingPolicy href="pathmap://PCM_MODELS/Palladio.resourcetype#FCFS"/>
+      <activeResourceType_ActiveResourceSpecification href="pathmap://PCM_MODELS/Palladio.resourcetype#_oro4gG3fEdy4YaaT-RYrLQ"/>
+      <processingRate_ProcessingResourceSpecification specification="1.0"/>
+    </activeResourceSpecifications_ResourceContainer>
+  </resourceContainer_ResourceEnvironment>
+</resourceenvironment:ResourceEnvironment>

--- a/examples/headless-simulation/models/minimal.spd
+++ b/examples/headless-simulation/models/minimal.spd
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<spd:SPD xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:spd="http://palladiosimulator.org/ScalingPolicyDefinition/1.0" id="_JPMJ0Mb4Ee2r2LzXTxtdFg" entityName="empty"/>

--- a/examples/headless-simulation/models/minimal.system
+++ b/examples/headless-simulation/models/minimal.system
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="ASCII"?>
+<system:System xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:composition="http://palladiosimulator.org/PalladioComponentModel/Core/Composition/5.2" xmlns:repository="http://palladiosimulator.org/PalladioComponentModel/Repository/5.2" xmlns:system="http://palladiosimulator.org/PalladioComponentModel/System/5.2" id="_CVBz0BDVEe6FXrMRahCZ6g" entityName="New System">
+  <assemblyContexts__ComposedStructure id="_07_00BDiEe6FXrMRahCZ6g" entityName="Assembly_BasicComponent1">
+    <encapsulatedComponent__AssemblyContext xsi:type="repository:BasicComponent" href="minimal.repository#_i05skBDiEe6FXrMRahCZ6g"/>
+  </assemblyContexts__ComposedStructure>
+  <connectors__ComposedStructure xsi:type="composition:ProvidedDelegationConnector" id="_2uCaMBDiEe6FXrMRahCZ6g" entityName="newProvidedDelegationConnector" outerProvidedRole_ProvidedDelegationConnector="_z5AGwBDiEe6FXrMRahCZ6g" assemblyContext_ProvidedDelegationConnector="_07_00BDiEe6FXrMRahCZ6g">
+    <innerProvidedRole_ProvidedDelegationConnector href="minimal.repository#_nLjjwBDiEe6FXrMRahCZ6g"/>
+  </connectors__ComposedStructure>
+  <providedRoles_InterfaceProvidingEntity xsi:type="repository:OperationProvidedRole" id="_z5AGwBDiEe6FXrMRahCZ6g" entityName="Interface1ProvidedRole">
+    <providedInterface__OperationProvidedRole href="minimal.repository#_h6nOkBDiEe6FXrMRahCZ6g"/>
+  </providedRoles_InterfaceProvidingEntity>
+</system:System>

--- a/examples/headless-simulation/models/minimal.usagemodel
+++ b/examples/headless-simulation/models/minimal.usagemodel
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<usagemodel:UsageModel xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:usagemodel="http://palladiosimulator.org/PalladioComponentModel/UsageModel/5.2">
+  <usageScenario_UsageModel id="_LPnI8CHdEd6lJo4DCALHMw" entityName="ClosedWorkloadUsageScenario">
+    <scenarioBehaviour_UsageScenario id="_LPwS4CHdEd6lJo4DCALHMw" entityName="defaultUsageScenarioBehaviour">
+      <actions_ScenarioBehaviour xsi:type="usagemodel:Start" id="_LPwS4SHdEd6lJo4DCALHMw" successor="_NvVLkBDjEe6FXrMRahCZ6g"/>
+      <actions_ScenarioBehaviour xsi:type="usagemodel:Stop" id="_LPwS4iHdEd6lJo4DCALHMw" predecessor="_NvVLkBDjEe6FXrMRahCZ6g"/>
+      <actions_ScenarioBehaviour xsi:type="usagemodel:EntryLevelSystemCall" id="_NvVLkBDjEe6FXrMRahCZ6g" entityName="EntryLevelSystemCall1" successor="_LPwS4iHdEd6lJo4DCALHMw" predecessor="_LPwS4SHdEd6lJo4DCALHMw">
+        <providedRole_EntryLevelSystemCall href="minimal.system#_z5AGwBDiEe6FXrMRahCZ6g"/>
+        <operationSignature__EntryLevelSystemCall href="minimal.repository#_k2ph4BDiEe6FXrMRahCZ6g"/>
+      </actions_ScenarioBehaviour>
+    </scenarioBehaviour_UsageScenario>
+    <workload_UsageScenario xsi:type="usagemodel:ClosedWorkload" population="1">
+      <thinkTime_ClosedWorkload specification="DoublePDF[( 1.0 ; 0.6 ) ( 2.0 ; 0.2 ) ( 4.0 ; 0.2 )]"/>
+    </workload_UsageScenario>
+  </usageScenario_UsageModel>
+</usagemodel:UsageModel>

--- a/examples/headless-simulation/run.sh
+++ b/examples/headless-simulation/run.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+#
+# Slingshot Headless — Example Simulation Runner
+#
+# This script builds the headless product and runs the MinimalModel example.
+# Adjust JAVA_HOME to point to a JDK 17+ installation.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+PRODUCT_DIR="$PROJECT_DIR/releng/org.palladiosimulator.analyzer.slingshot.headless.product"
+MODEL_DIR="$SCRIPT_DIR/models/MinimalModel"
+
+# Use provided JAVA_HOME or try to find JDK 17
+if [ -z "${JAVA_HOME:-}" ]; then
+    if [ -d "/Library/Java/JavaVirtualMachines/openjdk-17.jdk/Contents/Home" ]; then
+        JAVA_HOME="/Library/Java/JavaVirtualMachines/openjdk-17.jdk/Contents/Home"
+    else
+        echo "Error: JAVA_HOME not set. Please set it to a JDK 17+ installation."
+        exit 1
+    fi
+fi
+
+echo "=== Building Slingshot Headless Product ==="
+cd "$PROJECT_DIR"
+export JAVA_HOME
+mvn clean verify -q -DskipTests
+
+echo ""
+echo "=== Extracting Product ==="
+PRODUCT_ZIP=$(ls "$PRODUCT_DIR/target/products/"*macosx.cocoa.aarch64.zip 2>/dev/null || true)
+if [ -z "$PRODUCT_ZIP" ]; then
+    PRODUCT_ZIP=$(ls "$PRODUCT_DIR/target/products/"*.zip 2>/dev/null | head -1)
+fi
+
+if [ -z "$PRODUCT_ZIP" ]; then
+    echo "Error: No product archive found in $PRODUCT_DIR/target/products/"
+    exit 1
+fi
+
+EXTRACT_DIR=$(mktemp -d)
+unzip -q "$PRODUCT_ZIP" -d "$EXTRACT_DIR"
+
+LAUNCHER_JAR=$(find "$EXTRACT_DIR" -name "org.eclipse.equinox.launcher_*.jar" | head -1)
+if [ -z "$LAUNCHER_JAR" ]; then
+    echo "Error: Equinox launcher not found in extracted product"
+    exit 1
+fi
+
+echo ""
+echo "=== Running Simulation ==="
+java \
+    -jar "$LAUNCHER_JAR" \
+    -application org.palladiosimulator.analyzer.slingshot.headless.slingshotHeadless \
+    -data "$(mktemp -d)" \
+    --allocation "$MODEL_DIR/minimal.allocation" \
+    --repository "$MODEL_DIR/minimal.repository" \
+    --system "$MODEL_DIR/minimal.system" \
+    --resourceenvironment "$MODEL_DIR/minimal.resourceenvironment" \
+    --usagemodel "$MODEL_DIR/minimal.usagemodel" \
+    --simulationTime 10 \
+    --seed 12345
+
+echo ""
+echo "=== Simulation Complete ==="
+rm -rf "$EXTRACT_DIR"

--- a/features/org.palladiosimulator.analyzer.slingshot.feature/feature.xml
+++ b/features/org.palladiosimulator.analyzer.slingshot.feature/feature.xml
@@ -90,4 +90,11 @@
          version="0.0.0"
          unpack="false"/>
 
+   <plugin
+         id="org.palladiosimulator.analyzer.slingshot.headless"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
 </feature>

--- a/releng/org.palladiosimulator.analyzer.slingshot.headless.product/pom.xml
+++ b/releng/org.palladiosimulator.analyzer.slingshot.headless.product/pom.xml
@@ -1,0 +1,37 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.palladiosimulator.analyzer.slingshot</groupId>
+    <artifactId>releng</artifactId>
+    <version>0.0.2-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>org.palladiosimulator.analyzer.slingshot.headless.product</artifactId>
+  <packaging>eclipse-repository</packaging>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.eclipse.tycho</groupId>
+        <artifactId>tycho-p2-director-plugin</artifactId>
+        <version>2.7.5</version>
+        <executions>
+          <execution>
+            <id>materialize-products</id>
+            <goals>
+              <goal>materialize-products</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>archive-products</id>
+            <goals>
+              <goal>archive-products</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/releng/org.palladiosimulator.analyzer.slingshot.headless.product/slingshot-headless.product
+++ b/releng/org.palladiosimulator.analyzer.slingshot.headless.product/slingshot-headless.product
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?product
+      id="org.palladiosimulator.analyzer.slingshot.headless.product"
+      name="Slingshot Headless"
+      application="org.palladiosimulator.analyzer.slingshot.headless.slingshotHeadless"
+      version="1.0.0.qualifier"
+      useFeatures="true"
+      includeLaunchers="false"
+      autoIncludeRequirements="true"
+?>
+<product
+      uid="org.palladiosimulator.analyzer.slingshot.headless.product"
+      id="org.palladiosimulator.analyzer.slingshot.headless.product"
+      application="org.palladiosimulator.analyzer.slingshot.headless.slingshotHeadless"
+      version="1.0.0.qualifier"
+      name="Slingshot Headless"
+      useFeatures="true"
+      includeLaunchers="false"
+      autoIncludeRequirements="true">
+
+   <configIni use="default">
+   </configIni>
+
+   <features>
+      <feature id="org.palladiosimulator.analyzer.slingshot.feature"/>
+      <feature id="org.palladiosimulator.analyzer.slingshot.extension.pcm.core"/>
+      <feature id="org.palladiosimulator.analyzer.slingshot.extension.monitoring.feature"/>
+      <feature id="org.palladiosimulator.analyzer.slingshot.extension.spd.interpreter"/>
+   </features>
+
+   <configurations>
+      <plugin id="org.eclipse.core.runtime" autoStart="true" startLevel="4"/>
+      <plugin id="org.eclipse.equinox.common" autoStart="true" startLevel="2"/>
+      <plugin id="org.eclipse.equinox.ds" autoStart="true" startLevel="2"/>
+      <plugin id="org.eclipse.equinox.event" autoStart="true" startLevel="3"/>
+      <plugin id="org.eclipse.equinox.app" autoStart="true" startLevel="4"/>
+      <plugin id="org.palladiosimulator.analyzer.slingshot.core" autoStart="true" startLevel="4"/>
+      <plugin id="org.palladiosimulator.analyzer.slingshot.headless" autoStart="true" startLevel="4"/>
+   </configurations>
+</product>

--- a/releng/pom.xml
+++ b/releng/pom.xml
@@ -10,5 +10,6 @@
   
   <modules>
   	<module>org.palladiosimulator.analyzer.slingshot.updatesite</module>
+  	<module>org.palladiosimulator.analyzer.slingshot.headless.product</module>
   </modules>
 </project>

--- a/tests/org.palladiosimulator.analyzer.slingshot.headless.test/META-INF/MANIFEST.MF
+++ b/tests/org.palladiosimulator.analyzer.slingshot.headless.test/META-INF/MANIFEST.MF
@@ -1,0 +1,17 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: Headless CLI Test
+Bundle-SymbolicName: org.palladiosimulator.analyzer.slingshot.headless.test;singleton:=true
+Bundle-Version: 1.0.0.qualifier
+Automatic-Module-Name: org.palladiosimulator.analyzer.slingshot.headless.test
+Bundle-RequiredExecutionEnvironment: JavaSE-17
+Require-Bundle: org.junit.jupiter.api;bundle-version="5.8.1",
+ org.palladiosimulator.analyzer.slingshot.headless,
+ org.palladiosimulator.analyzer.slingshot.core,
+ org.palladiosimulator.analyzer.workflow.core,
+ de.uka.ipd.sdq.workflow.mdsd.blackboard,
+ org.palladiosimulator.pcm,
+ org.palladiosimulator.pcm.resources,
+ org.eclipse.core.runtime,
+ org.eclipse.emf.ecore,
+ org.eclipse.emf.common

--- a/tests/org.palladiosimulator.analyzer.slingshot.headless.test/build.properties
+++ b/tests/org.palladiosimulator.analyzer.slingshot.headless.test/build.properties
@@ -1,0 +1,5 @@
+source.. = src/
+output.. = bin/
+bin.includes = META-INF/,\
+               .,\
+               models/

--- a/tests/org.palladiosimulator.analyzer.slingshot.headless.test/models/MinimalModel/minimal.allocation
+++ b/tests/org.palladiosimulator.analyzer.slingshot.headless.test/models/MinimalModel/minimal.allocation
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="ASCII"?>
+<allocation:Allocation xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:allocation="http://palladiosimulator.org/PalladioComponentModel/Allocation/5.2" id="_GgAmgBDVEe6FXrMRahCZ6g" entityName="New Allocation">
+  <targetResourceEnvironment_Allocation href="minimal.resourceenvironment#/"/>
+  <system_Allocation href="minimal.system#_CVBz0BDVEe6FXrMRahCZ6g"/>
+  <allocationContexts_Allocation id="_FsIKIBDjEe6FXrMRahCZ6g" entityName="Allocation_Assembly_BasicComponent1">
+    <resourceContainer_AllocationContext href="minimal.resourceenvironment#_9pUxUBDiEe6FXrMRahCZ6g"/>
+    <assemblyContext_AllocationContext href="minimal.system#_07_00BDiEe6FXrMRahCZ6g"/>
+  </allocationContexts_Allocation>
+</allocation:Allocation>

--- a/tests/org.palladiosimulator.analyzer.slingshot.headless.test/models/MinimalModel/minimal.measuringpoint
+++ b/tests/org.palladiosimulator.analyzer.slingshot.headless.test/models/MinimalModel/minimal.measuringpoint
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<org.palladiosimulator.edp2.models:MeasuringPointRepository xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:org.palladiosimulator.edp2.models="http://palladiosimulator.org/EDP2/MeasuringPoint/1.0" xmlns:pcmmeasuringpoint="http://palladiosimulator.org/PCM/MeasuringPoint/1.0" id="_DgOGgBDTEe6FXrMRahCZ6g">
+  <measuringPoints xsi:type="pcmmeasuringpoint:UsageScenarioMeasuringPoint" stringRepresentation="Usage Scenario: ClosedWorkloadUsageScenario" resourceURIRepresentation="platform:/resource/testCaseEditing/minimalModelSet.usageModelOnly/minimal.usagemodel#_LPnI8CHdEd6lJo4DCALHMw">
+    <usageScenario href="minimal.usagemodel#_LPnI8CHdEd6lJo4DCALHMw"/>
+  </measuringPoints>
+</org.palladiosimulator.edp2.models:MeasuringPointRepository>

--- a/tests/org.palladiosimulator.analyzer.slingshot.headless.test/models/MinimalModel/minimal.monitorrepository
+++ b/tests/org.palladiosimulator.analyzer.slingshot.headless.test/models/MinimalModel/minimal.monitorrepository
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<monitorrepository:MonitorRepository xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:metricspec="http://palladiosimulator.org/MetricSpec/1.0" xmlns:monitorrepository="http://palladiosimulator.org/MonitorRepository/1.0" xmlns:pcmmeasuringpoint="http://palladiosimulator.org/PCM/MeasuringPoint/1.0" id="_Av7JIBDTEe6FXrMRahCZ6g">
+  <monitors id="_HVyC0BDTEe6FXrMRahCZ6g">
+    <measurementSpecifications id="_JmmO4BDTEe6FXrMRahCZ6g">
+      <metricDescription xsi:type="metricspec:NumericalBaseMetricDescription" href="pathmap://METRIC_SPEC_MODELS/commonMetrics.metricspec#_6rYmYs7nEeOX_4BzImuHbA"/>
+      <processingType xsi:type="monitorrepository:FeedThrough" id="_N5hcoBDTEe6FXrMRahCZ6g"/>
+    </measurementSpecifications>
+    <measuringPoint xsi:type="pcmmeasuringpoint:UsageScenarioMeasuringPoint" href="minimal.measuringpoint#//@measuringPoints.0"/>
+  </monitors>
+</monitorrepository:MonitorRepository>

--- a/tests/org.palladiosimulator.analyzer.slingshot.headless.test/models/MinimalModel/minimal.repository
+++ b/tests/org.palladiosimulator.analyzer.slingshot.headless.test/models/MinimalModel/minimal.repository
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="ASCII"?>
+<repository:Repository xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:repository="http://palladiosimulator.org/PalladioComponentModel/Repository/5.2" xmlns:seff="http://palladiosimulator.org/PalladioComponentModel/SEFF/5.2" id="_bhko4BDiEe6FXrMRahCZ6g" entityName="New Repository">
+  <components__Repository xsi:type="repository:BasicComponent" id="_i05skBDiEe6FXrMRahCZ6g" entityName="BasicComponent1">
+    <providedRoles_InterfaceProvidingEntity xsi:type="repository:OperationProvidedRole" id="_nLjjwBDiEe6FXrMRahCZ6g" entityName="BasicComponent1.Interface1.OperationProvidedRole1" providedInterface__OperationProvidedRole="_h6nOkBDiEe6FXrMRahCZ6g"/>
+    <serviceEffectSpecifications__BasicComponent xsi:type="seff:ResourceDemandingSEFF" id="_nL4T4BDiEe6FXrMRahCZ6g" describedService__SEFF="_k2ph4BDiEe6FXrMRahCZ6g">
+      <steps_Behaviour xsi:type="seff:StartAction" id="_nL6JEBDiEe6FXrMRahCZ6g" successor_AbstractAction="_obMmsBDiEe6FXrMRahCZ6g"/>
+      <steps_Behaviour xsi:type="seff:StopAction" id="_nL6wIBDiEe6FXrMRahCZ6g" predecessor_AbstractAction="_obMmsBDiEe6FXrMRahCZ6g"/>
+      <steps_Behaviour xsi:type="seff:InternalAction" id="_obMmsBDiEe6FXrMRahCZ6g" entityName="InternalAction1" predecessor_AbstractAction="_nL6JEBDiEe6FXrMRahCZ6g" successor_AbstractAction="_nL6wIBDiEe6FXrMRahCZ6g">
+        <resourceDemand_Action>
+          <specification_ParametericResourceDemand specification="1.0"/>
+          <requiredResource_ParametricResourceDemand href="pathmap://PCM_MODELS/Palladio.resourcetype#_oro4gG3fEdy4YaaT-RYrLQ"/>
+        </resourceDemand_Action>
+      </steps_Behaviour>
+    </serviceEffectSpecifications__BasicComponent>
+  </components__Repository>
+  <interfaces__Repository xsi:type="repository:OperationInterface" id="_h6nOkBDiEe6FXrMRahCZ6g" entityName="Interface1">
+    <signatures__OperationInterface id="_k2ph4BDiEe6FXrMRahCZ6g" entityName="method1"/>
+  </interfaces__Repository>
+</repository:Repository>

--- a/tests/org.palladiosimulator.analyzer.slingshot.headless.test/models/MinimalModel/minimal.resourceenvironment
+++ b/tests/org.palladiosimulator.analyzer.slingshot.headless.test/models/MinimalModel/minimal.resourceenvironment
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="ASCII"?>
+<resourceenvironment:ResourceEnvironment xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:resourceenvironment="http://palladiosimulator.org/PalladioComponentModel/ResourceEnvironment/5.2" entityName="New ResourceEnvironment">
+  <resourceContainer_ResourceEnvironment id="_9pUxUBDiEe6FXrMRahCZ6g" entityName="ResourceContainer1">
+    <activeResourceSpecifications_ResourceContainer id="_-dbu0BDiEe6FXrMRahCZ6g">
+      <schedulingPolicy href="pathmap://PCM_MODELS/Palladio.resourcetype#FCFS"/>
+      <activeResourceType_ActiveResourceSpecification href="pathmap://PCM_MODELS/Palladio.resourcetype#_oro4gG3fEdy4YaaT-RYrLQ"/>
+      <processingRate_ProcessingResourceSpecification specification="1.0"/>
+    </activeResourceSpecifications_ResourceContainer>
+  </resourceContainer_ResourceEnvironment>
+</resourceenvironment:ResourceEnvironment>

--- a/tests/org.palladiosimulator.analyzer.slingshot.headless.test/models/MinimalModel/minimal.spd
+++ b/tests/org.palladiosimulator.analyzer.slingshot.headless.test/models/MinimalModel/minimal.spd
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<spd:SPD xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:spd="http://palladiosimulator.org/ScalingPolicyDefinition/1.0" id="_JPMJ0Mb4Ee2r2LzXTxtdFg" entityName="empty"/>

--- a/tests/org.palladiosimulator.analyzer.slingshot.headless.test/models/MinimalModel/minimal.system
+++ b/tests/org.palladiosimulator.analyzer.slingshot.headless.test/models/MinimalModel/minimal.system
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="ASCII"?>
+<system:System xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:composition="http://palladiosimulator.org/PalladioComponentModel/Core/Composition/5.2" xmlns:repository="http://palladiosimulator.org/PalladioComponentModel/Repository/5.2" xmlns:system="http://palladiosimulator.org/PalladioComponentModel/System/5.2" id="_CVBz0BDVEe6FXrMRahCZ6g" entityName="New System">
+  <assemblyContexts__ComposedStructure id="_07_00BDiEe6FXrMRahCZ6g" entityName="Assembly_BasicComponent1">
+    <encapsulatedComponent__AssemblyContext xsi:type="repository:BasicComponent" href="minimal.repository#_i05skBDiEe6FXrMRahCZ6g"/>
+  </assemblyContexts__ComposedStructure>
+  <connectors__ComposedStructure xsi:type="composition:ProvidedDelegationConnector" id="_2uCaMBDiEe6FXrMRahCZ6g" entityName="newProvidedDelegationConnector" outerProvidedRole_ProvidedDelegationConnector="_z5AGwBDiEe6FXrMRahCZ6g" assemblyContext_ProvidedDelegationConnector="_07_00BDiEe6FXrMRahCZ6g">
+    <innerProvidedRole_ProvidedDelegationConnector href="minimal.repository#_nLjjwBDiEe6FXrMRahCZ6g"/>
+  </connectors__ComposedStructure>
+  <providedRoles_InterfaceProvidingEntity xsi:type="repository:OperationProvidedRole" id="_z5AGwBDiEe6FXrMRahCZ6g" entityName="Interface1ProvidedRole">
+    <providedInterface__OperationProvidedRole href="minimal.repository#_h6nOkBDiEe6FXrMRahCZ6g"/>
+  </providedRoles_InterfaceProvidingEntity>
+</system:System>

--- a/tests/org.palladiosimulator.analyzer.slingshot.headless.test/models/MinimalModel/minimal.usagemodel
+++ b/tests/org.palladiosimulator.analyzer.slingshot.headless.test/models/MinimalModel/minimal.usagemodel
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<usagemodel:UsageModel xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:usagemodel="http://palladiosimulator.org/PalladioComponentModel/UsageModel/5.2">
+  <usageScenario_UsageModel id="_LPnI8CHdEd6lJo4DCALHMw" entityName="ClosedWorkloadUsageScenario">
+    <scenarioBehaviour_UsageScenario id="_LPwS4CHdEd6lJo4DCALHMw" entityName="defaultUsageScenarioBehaviour">
+      <actions_ScenarioBehaviour xsi:type="usagemodel:Start" id="_LPwS4SHdEd6lJo4DCALHMw" successor="_NvVLkBDjEe6FXrMRahCZ6g"/>
+      <actions_ScenarioBehaviour xsi:type="usagemodel:Stop" id="_LPwS4iHdEd6lJo4DCALHMw" predecessor="_NvVLkBDjEe6FXrMRahCZ6g"/>
+      <actions_ScenarioBehaviour xsi:type="usagemodel:EntryLevelSystemCall" id="_NvVLkBDjEe6FXrMRahCZ6g" entityName="EntryLevelSystemCall1" successor="_LPwS4iHdEd6lJo4DCALHMw" predecessor="_LPwS4SHdEd6lJo4DCALHMw">
+        <providedRole_EntryLevelSystemCall href="minimal.system#_z5AGwBDiEe6FXrMRahCZ6g"/>
+        <operationSignature__EntryLevelSystemCall href="minimal.repository#_k2ph4BDiEe6FXrMRahCZ6g"/>
+      </actions_ScenarioBehaviour>
+    </scenarioBehaviour_UsageScenario>
+    <workload_UsageScenario xsi:type="usagemodel:ClosedWorkload" population="1">
+      <thinkTime_ClosedWorkload specification="DoublePDF[( 1.0 ; 0.6 ) ( 2.0 ; 0.2 ) ( 4.0 ; 0.2 )]"/>
+    </workload_UsageScenario>
+  </usageScenario_UsageModel>
+</usagemodel:UsageModel>

--- a/tests/org.palladiosimulator.analyzer.slingshot.headless.test/models/usageModelOnly/delay.allocation
+++ b/tests/org.palladiosimulator.analyzer.slingshot.headless.test/models/usageModelOnly/delay.allocation
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="ASCII"?>
+<allocation:Allocation xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:allocation="http://palladiosimulator.org/PalladioComponentModel/Allocation/5.2" id="_GgAmgBDVEe6FXrMRahCZ6g" entityName="New Allocation">
+  <targetResourceEnvironment_Allocation href="delay.resourceenvironment#/"/>
+  <system_Allocation href="delay.system#_CVBz0BDVEe6FXrMRahCZ6g"/>
+</allocation:Allocation>

--- a/tests/org.palladiosimulator.analyzer.slingshot.headless.test/models/usageModelOnly/delay.measuringpoint
+++ b/tests/org.palladiosimulator.analyzer.slingshot.headless.test/models/usageModelOnly/delay.measuringpoint
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<org.palladiosimulator.edp2.models:MeasuringPointRepository xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:org.palladiosimulator.edp2.models="http://palladiosimulator.org/EDP2/MeasuringPoint/1.0" xmlns:pcmmeasuringpoint="http://palladiosimulator.org/PCM/MeasuringPoint/1.0" id="_DgOGgBDTEe6FXrMRahCZ6g">
+  <measuringPoints xsi:type="pcmmeasuringpoint:UsageScenarioMeasuringPoint" stringRepresentation="Usage Scenario: ClosedWorkloadUsageScenario" resourceURIRepresentation="platform:/resource/testCaseEditing/minimalModelSet.usageModelOnly/delay.usagemodel#_LPnI8CHdEd6lJo4DCALHMw">
+    <usageScenario href="delay.usagemodel#_LPnI8CHdEd6lJo4DCALHMw"/>
+  </measuringPoints>
+</org.palladiosimulator.edp2.models:MeasuringPointRepository>

--- a/tests/org.palladiosimulator.analyzer.slingshot.headless.test/models/usageModelOnly/delay.monitorrepository
+++ b/tests/org.palladiosimulator.analyzer.slingshot.headless.test/models/usageModelOnly/delay.monitorrepository
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<monitorrepository:MonitorRepository xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:metricspec="http://palladiosimulator.org/MetricSpec/1.0" xmlns:monitorrepository="http://palladiosimulator.org/MonitorRepository/1.0" xmlns:pcmmeasuringpoint="http://palladiosimulator.org/PCM/MeasuringPoint/1.0" id="_Av7JIBDTEe6FXrMRahCZ6g">
+  <monitors id="_HVyC0BDTEe6FXrMRahCZ6g">
+    <measurementSpecifications id="_JmmO4BDTEe6FXrMRahCZ6g">
+      <metricDescription xsi:type="metricspec:NumericalBaseMetricDescription" href="pathmap://METRIC_SPEC_MODELS/commonMetrics.metricspec#_6rYmYs7nEeOX_4BzImuHbA"/>
+      <processingType xsi:type="monitorrepository:FeedThrough" id="_N5hcoBDTEe6FXrMRahCZ6g"/>
+    </measurementSpecifications>
+    <measuringPoint xsi:type="pcmmeasuringpoint:UsageScenarioMeasuringPoint" href="delay.measuringpoint#//@measuringPoints.0"/>
+  </monitors>
+</monitorrepository:MonitorRepository>

--- a/tests/org.palladiosimulator.analyzer.slingshot.headless.test/models/usageModelOnly/delay.resourceenvironment
+++ b/tests/org.palladiosimulator.analyzer.slingshot.headless.test/models/usageModelOnly/delay.resourceenvironment
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="ASCII"?>
+<resourceenvironment:ResourceEnvironment xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:resourceenvironment="http://palladiosimulator.org/PalladioComponentModel/ResourceEnvironment/5.2" entityName="New ResourceEnvironment"/>

--- a/tests/org.palladiosimulator.analyzer.slingshot.headless.test/models/usageModelOnly/delay.spd
+++ b/tests/org.palladiosimulator.analyzer.slingshot.headless.test/models/usageModelOnly/delay.spd
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<spd:SPD xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:spd="http://palladiosimulator.org/ScalingPolicyDefinition/1.0" id="_JPMJ0Mb4Ee2r2LzXTxtdFg" entityName="empty"/>

--- a/tests/org.palladiosimulator.analyzer.slingshot.headless.test/models/usageModelOnly/delay.system
+++ b/tests/org.palladiosimulator.analyzer.slingshot.headless.test/models/usageModelOnly/delay.system
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="ASCII"?>
+<system:System xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:system="http://palladiosimulator.org/PalladioComponentModel/System/5.2" id="_CVBz0BDVEe6FXrMRahCZ6g" entityName="New System"/>

--- a/tests/org.palladiosimulator.analyzer.slingshot.headless.test/models/usageModelOnly/delay.usagemodel
+++ b/tests/org.palladiosimulator.analyzer.slingshot.headless.test/models/usageModelOnly/delay.usagemodel
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<usagemodel:UsageModel xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:usagemodel="http://palladiosimulator.org/PalladioComponentModel/UsageModel/5.2">
+  <usageScenario_UsageModel id="_LPnI8CHdEd6lJo4DCALHMw" entityName="ClosedWorkloadUsageScenario">
+    <scenarioBehaviour_UsageScenario id="_LPwS4CHdEd6lJo4DCALHMw" entityName="defaultUsageScenarioBehaviour">
+      <actions_ScenarioBehaviour xsi:type="usagemodel:Start" id="_LPwS4SHdEd6lJo4DCALHMw" successor="_k1r2gPlSEe2_POqiFokumQ"/>
+      <actions_ScenarioBehaviour xsi:type="usagemodel:Stop" id="_LPwS4iHdEd6lJo4DCALHMw" predecessor="_k1r2gPlSEe2_POqiFokumQ"/>
+      <actions_ScenarioBehaviour xsi:type="usagemodel:Delay" id="_k1r2gPlSEe2_POqiFokumQ" entityName="Delay1" successor="_LPwS4iHdEd6lJo4DCALHMw" predecessor="_LPwS4SHdEd6lJo4DCALHMw">
+        <timeSpecification_Delay specification="1.0"/>
+      </actions_ScenarioBehaviour>
+    </scenarioBehaviour_UsageScenario>
+    <workload_UsageScenario xsi:type="usagemodel:ClosedWorkload" population="1">
+      <thinkTime_ClosedWorkload specification="DoublePDF[( 1.0 ; 0.6 ) ( 2.0 ; 0.2 ) ( 4.0 ; 0.2 )]"/>
+    </workload_UsageScenario>
+  </usageScenario_UsageModel>
+</usagemodel:UsageModel>

--- a/tests/org.palladiosimulator.analyzer.slingshot.headless.test/src/org/palladiosimulator/analyzer/slingshot/headless/test/HeadlessCliTest.java
+++ b/tests/org.palladiosimulator.analyzer.slingshot.headless.test/src/org/palladiosimulator/analyzer/slingshot/headless/test/HeadlessCliTest.java
@@ -1,0 +1,61 @@
+package org.palladiosimulator.analyzer.slingshot.headless.test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.palladiosimulator.analyzer.slingshot.core.Slingshot;
+import org.palladiosimulator.analyzer.slingshot.core.api.SimulationDriver;
+
+class HeadlessCliTest {
+
+	private static String minimalModelPath;
+	private static String usageModelOnlyPath;
+
+	@BeforeAll
+	static void setUp() {
+		final File modelsDir = new File("models");
+		if (modelsDir.exists()) {
+			minimalModelPath = new File(modelsDir, "MinimalModel").getAbsolutePath();
+			usageModelOnlyPath = new File(modelsDir, "usageModelOnly").getAbsolutePath();
+		} else {
+			final File fallback = new File(
+					"tests/org.palladiosimulator.analyzer.slingshot.headless.test/models");
+			minimalModelPath = new File(fallback, "MinimalModel").getAbsolutePath();
+			usageModelOnlyPath = new File(fallback, "usageModelOnly").getAbsolutePath();
+		}
+	}
+
+	@Test
+	void modelDirectoriesExist() {
+		assertTrue(new File(minimalModelPath).exists(),
+				"MinimalModel directory should exist at: " + minimalModelPath);
+		assertTrue(new File(usageModelOnlyPath).exists(),
+				"usageModelOnly directory should exist at: " + usageModelOnlyPath);
+	}
+
+	@Test
+	void slingshotInstanceIsAvailable() {
+		assertNotNull(Slingshot.getInstance());
+		final SimulationDriver driver = Slingshot.getInstance().getSimulationDriver();
+		assertNotNull(driver);
+	}
+
+	@Test
+	void minimalModelLoadsIntoBlackboard() {
+		final HeadlessTestRun run = assertDoesNotThrow(() -> new HeadlessTestRun(minimalModelPath));
+		assertTrue(run.modelsLoaded());
+		assertNotNull(run.getPartition());
+	}
+
+	@Test
+	void usageModelLoadsIntoBlackboard() {
+		final HeadlessTestRun run = assertDoesNotThrow(() -> new HeadlessTestRun(usageModelOnlyPath));
+		assertTrue(run.modelsLoaded());
+		assertNotNull(run.getPartition());
+	}
+}

--- a/tests/org.palladiosimulator.analyzer.slingshot.headless.test/src/org/palladiosimulator/analyzer/slingshot/headless/test/HeadlessTestRun.java
+++ b/tests/org.palladiosimulator.analyzer.slingshot.headless.test/src/org/palladiosimulator/analyzer/slingshot/headless/test/HeadlessTestRun.java
@@ -1,0 +1,63 @@
+package org.palladiosimulator.analyzer.slingshot.headless.test;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.emf.common.util.URI;
+import org.palladiosimulator.analyzer.slingshot.core.extension.PCMResourceSetPartitionProvider;
+import org.palladiosimulator.analyzer.workflow.core.ConstantsContainer;
+import org.palladiosimulator.analyzer.workflow.core.blackboard.PCMResourceSetPartition;
+import org.palladiosimulator.analyzer.workflow.core.jobs.LoadModelIntoBlackboardJob;
+import org.palladiosimulator.analyzer.workflow.core.jobs.PreparePCMBlackboardPartitionJob;
+
+import de.uka.ipd.sdq.workflow.mdsd.blackboard.MDSDBlackboard;
+
+public class HeadlessTestRun {
+
+	private final MDSDBlackboard blackboard;
+	private final String partitionId;
+
+	public HeadlessTestRun(final String modelDirPath) throws Exception {
+		this.blackboard = new MDSDBlackboard();
+		this.partitionId = ConstantsContainer.DEFAULT_PCM_INSTANCE_PARTITION_ID;
+
+		final NullProgressMonitor monitor = new NullProgressMonitor();
+
+		final PreparePCMBlackboardPartitionJob partitionJob = new PreparePCMBlackboardPartitionJob();
+		partitionJob.setBlackboard(this.blackboard);
+		partitionJob.execute(monitor);
+
+		final File modelDir = new File(modelDirPath);
+		final File[] modelFiles = modelDir.listFiles((dir, name) -> {
+			final String lower = name.toLowerCase();
+			return lower.endsWith(".allocation") || lower.endsWith(".repository")
+					|| lower.endsWith(".system") || lower.endsWith(".resourceenvironment")
+					|| lower.endsWith(".usagemodel");
+		});
+
+		if (modelFiles == null || modelFiles.length == 0) {
+			throw new IllegalArgumentException("No PCM model files found in: " + modelDirPath);
+		}
+
+		for (final File modelFile : modelFiles) {
+			final LoadModelIntoBlackboardJob loadJob = new LoadModelIntoBlackboardJob(
+					URI.createFileURI(modelFile.getAbsolutePath()), this.partitionId);
+			loadJob.setBlackboard(this.blackboard);
+			loadJob.execute(monitor);
+		}
+	}
+
+	public PCMResourceSetPartition getPartition() {
+		return (PCMResourceSetPartition) this.blackboard.getPartition(this.partitionId);
+	}
+
+	public MDSDBlackboard getBlackboard() {
+		return this.blackboard;
+	}
+
+	public boolean modelsLoaded() {
+		return this.blackboard.getPartition(this.partitionId) != null;
+	}
+}

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -11,5 +11,6 @@
   
   <modules>
   	<module>org.palladiosimulator.analyzer.slingshot.eventdriver.test</module>
+  	<module>org.palladiosimulator.analyzer.slingshot.headless.test</module>
   </modules>
 </project>


### PR DESCRIPTION
## Summary

Adds a headless Eclipse RCP product that runs Slingshot simulations directly from the CLI, without the Eclipse/Palladio Bench IDE.

## Changes

- **New bundle** - IApplication entry point with CLI argument parsing (--allocation, --repository, --system, --usagemodel, --simulationTime, --seed, etc.)
- **New product** - Eclipse .product definition packaging all Slingshot features except UI bundles
- **Test fragment** - 4 tests verifying model loading with real PCM model files (MinimalModel, UsageModelOnly) from the E2E test repository
- **Documentation** - ADR 001 (architecture decision record), requirements doc
- **Example** - MinimalModel PCM files + README + run script for end users

## Build

JAVA_HOME=/path/to/jdk17 mvn clean verify

Product archives are generated at releng/.../headless.product/target/products/ for macOS, Linux, and Windows.